### PR TITLE
Migrate reigh-worker to runpod-lifecycle package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ Wan2GP_original
 # Supabase edge functions (managed separately)
 supabase/
 .env.example
+
+# live_test run artifacts
+scripts/live_test/runs/

--- a/debug/commands/storage.py
+++ b/debug/commands/storage.py
@@ -15,13 +15,14 @@ def run(client: DebugClient, options: dict):
     print("=" * 80)
     
     try:
-        from gpu_orchestrator.runpod_client import create_runpod_client, get_network_volumes
-        
-        runpod_client = create_runpod_client()
-        
+        from runpod_lifecycle import RunPodConfig, get_network_volumes
+        from runpod_lifecycle.storage import get_storage_volume_id
+
+        runpod_config = RunPodConfig.from_env()
+
         # Get all storage volumes from RunPod
         print("\n📊 RunPod Network Volumes:\n")
-        volumes = get_network_volumes(runpod_client.api_key)
+        volumes = get_network_volumes(runpod_config.api_key)
         
         if not volumes:
             print("   No network volumes found")
@@ -72,11 +73,11 @@ def run(client: DebugClient, options: dict):
             print(f"   {'='*60}")
             
             # Get volume ID
-            volume_id = runpod_client._get_storage_volume_id(storage_name)
+            volume_id = get_storage_volume_id(runpod_config.api_key, storage_name)
             if not volume_id:
                 print(f"      ❌ Could not find volume ID")
                 continue
-            
+
             # Pick a worker with recent heartbeat
             check_worker = None
             for w in storage_workers:
@@ -84,23 +85,23 @@ def run(client: DebugClient, options: dict):
                 if runpod_id:
                     check_worker = w
                     break
-            
+
             if not check_worker:
                 print(f"      ❌ No worker available to SSH")
                 continue
-            
+
             runpod_id = check_worker.get('metadata', {}).get('runpod_id')
             print(f"      Checking via worker: {check_worker['id']}")
             print(f"      RunPod ID: {runpod_id}")
-            
-            # Check storage health
-            health = runpod_client.check_storage_health(
-                storage_name=storage_name,
-                volume_id=volume_id,
-                active_runpod_id=runpod_id,
+
+            # Check storage health via the pod's SSH
+            import asyncio
+            from runpod_lifecycle import get_pod
+            pod = asyncio.run(get_pod(runpod_id, runpod_config))
+            health = asyncio.run(pod.check_storage_health(
                 min_free_gb=int(os.getenv('STORAGE_MIN_FREE_GB', '50')),
-                max_percent_used=int(os.getenv('STORAGE_MAX_PERCENT_USED', '85'))
-            )
+                max_percent_used=int(os.getenv('STORAGE_MAX_PERCENT_USED', '85')),
+            ))
             
             print()
             if health.get('error'):
@@ -125,27 +126,28 @@ def run(client: DebugClient, options: dict):
         if expand_target:
             print(f"\n🔧 Expanding storage '{expand_target}'...")
             
-            volume_id = runpod_client._get_storage_volume_id(expand_target)
+            volume_id = get_storage_volume_id(runpod_config.api_key, expand_target)
             if not volume_id:
                 print(f"   ❌ Could not find volume ID for '{expand_target}'")
                 return False
-            
+
             # Get current size
-            volumes = get_network_volumes(runpod_client.api_key)
+            volumes = get_network_volumes(runpod_config.api_key)
             volume_info = next((v for v in volumes if v.get('name') == expand_target), None)
-            
+
             if not volume_info:
                 print(f"   ❌ Could not find volume info for '{expand_target}'")
                 return False
-            
+
             current_size = volume_info.get('size', 100)
             increment = int(os.getenv('STORAGE_EXPANSION_INCREMENT_GB', '50'))
             new_size = current_size + increment
-            
+
             print(f"   Current size: {current_size} GB")
             print(f"   New size: {new_size} GB (+{increment} GB)")
-            
-            if runpod_client._expand_network_volume(volume_id, new_size):
+
+            from runpod_lifecycle.storage import _expand_network_volume
+            if _expand_network_volume(runpod_config.api_key, volume_id, new_size):
                 print(f"   ✅ Successfully expanded to {new_size} GB!")
             else:
                 print(f"   ❌ Expansion failed for '{expand_target}'")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ dependencies = [
   "supabase>=2.23.0",
   "python-dotenv>=1.0.0",
   "replicate>=1.0.0",
+  "runpod-lifecycle @ git+https://github.com/banodoco/runpod-lifecycle@v0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/live_test/__init__.py
+++ b/scripts/live_test/__init__.py
@@ -1,0 +1,60 @@
+"""Shared package bootstrap for the live-test harness."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+WORKSPACE_ROOT = Path(__file__).resolve().parents[3]
+WORKER_ROOT = Path(__file__).resolve().parents[2]
+ORCHESTRATOR_ROOT = WORKSPACE_ROOT / "reigh-worker-orchestrator"
+
+
+def _add_path(path: Path) -> None:
+    resolved = str(path.resolve())
+    if path.exists() and resolved not in sys.path:
+        sys.path.insert(0, resolved)
+
+
+def ensure_orchestrator_imports() -> None:
+    _add_path(ORCHESTRATOR_ROOT)
+
+
+ensure_orchestrator_imports()
+
+_LAZY_EXPORTS = {
+    "DatabaseClient": ("gpu_orchestrator.database", "DatabaseClient"),
+    "RunPodConfig": ("runpod_lifecycle", "RunPodConfig"),
+    "SSHClient": ("runpod_lifecycle.ssh", "SSHClient"),
+    "get_pod_ssh_details": ("runpod_lifecycle.api", "get_pod_ssh_details"),
+    "terminate_pod": ("runpod_lifecycle.api", "terminate_pod"),
+    "launch": ("runpod_lifecycle", "launch"),
+    "get_network_volumes": ("runpod_lifecycle", "get_network_volumes"),
+}
+
+
+def __getattr__(name: str):
+    if name not in _LAZY_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_name, attr_name = _LAZY_EXPORTS[name]
+    module = importlib.import_module(module_name)
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value
+
+
+__all__ = [
+    "DatabaseClient",
+    "ORCHESTRATOR_ROOT",
+    "RunPodConfig",
+    "SSHClient",
+    "WORKER_ROOT",
+    "WORKSPACE_ROOT",
+    "ensure_orchestrator_imports",
+    "get_network_volumes",
+    "get_pod_ssh_details",
+    "launch",
+    "terminate_pod",
+]

--- a/scripts/live_test/completion_poller.py
+++ b/scripts/live_test/completion_poller.py
@@ -1,0 +1,191 @@
+"""Task completion polling and generation lookup for live worker tests."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+
+TERMINAL_STATUSES = {"Complete", "Failed", "Cancelled"}
+
+
+@dataclass(frozen=True)
+class TaskResult:
+    task_id: str
+    case_name: str
+    task_type: str
+    final_status: str
+    output_location: str | None
+    generation_ids: list[str]
+    elapsed_sec: float
+    error_summary: str | None
+
+
+def _coerce_rows(result: Any) -> list[dict[str, Any]]:
+    data = getattr(result, "data", None)
+    if not data:
+        return []
+    if isinstance(data, dict):
+        return [data]
+    return [row for row in data if isinstance(row, dict)]
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    normalized = str(value).replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _linked_generation_ids(rows: list[dict[str, Any]], task_id: str) -> tuple[list[str], str | None]:
+    generation_ids: list[str] = []
+    seen_generation_ids: set[str] = set()
+    first_location: str | None = None
+    for row in rows:
+        linked = False
+        tasks = row.get("tasks")
+        if isinstance(tasks, str):
+            linked = tasks.strip() == task_id
+        elif isinstance(tasks, list):
+            linked = any(isinstance(item, str) and item.strip() == task_id for item in tasks)
+
+        params = row.get("params")
+        if not linked and isinstance(params, dict):
+            linked = str(params.get("source_task_id", "")).strip() == task_id
+
+        if not linked:
+            continue
+
+        generation_id = row.get("id")
+        if generation_id:
+            normalized_id = str(generation_id)
+            if normalized_id not in seen_generation_ids:
+                generation_ids.append(normalized_id)
+                seen_generation_ids.add(normalized_id)
+        if first_location is None and row.get("location"):
+            first_location = str(row["location"])
+
+    return generation_ids, first_location
+
+
+def _fetch_task_row(db, task_id: str, project_id: str) -> dict[str, Any] | None:
+    rows = _coerce_rows(
+        db.supabase.table("tasks")
+        .select("id, task_type, status, output_location, error_message, created_at, project_id")
+        .eq("id", task_id)
+        .eq("project_id", project_id)
+        .execute()
+    )
+    return rows[0] if rows else None
+
+
+def _fetch_generations_since(
+    db,
+    *,
+    task_id: str,
+    project_id: str,
+    task_created_at: str | None,
+) -> tuple[list[str], str | None]:
+    query = (
+        db.supabase.table("generations")
+        .select("id, tasks, params, location, created_at, project_id")
+        .eq("project_id", project_id)
+    )
+    if task_created_at:
+        query = query.gte("created_at", task_created_at)
+
+    rows = _coerce_rows(query.execute())
+    if task_created_at:
+        created_cutoff = _parse_timestamp(task_created_at)
+        filtered_rows = []
+        for row in rows:
+            row_created_at = _parse_timestamp(row.get("created_at"))
+            if created_cutoff is None or row_created_at is None or row_created_at >= created_cutoff:
+                filtered_rows.append(row)
+        rows = filtered_rows
+
+    return _linked_generation_ids(rows, task_id)
+
+
+def _failure_summary(task_row: dict[str, Any] | None, final_status: str, generation_ids: list[str]) -> str | None:
+    if task_row is None:
+        return "Task row disappeared before completion polling finished"
+
+    if final_status in {"Failed", "Cancelled"}:
+        return (
+            task_row.get("error_message")
+            or task_row.get("output_location")
+            or f"Task reached terminal status {final_status}"
+        )
+
+    if final_status == "Complete" and not generation_ids:
+        return "Task completed but no linked generations were found"
+
+    return None
+
+
+def poll_until_complete(
+    db,
+    task_id: str,
+    project_id: str,
+    *,
+    timeout_sec: int,
+    interval_sec: int = 5,
+    case_name: str | None = None,
+    task_type: str | None = None,
+) -> TaskResult:
+    """Poll a task row until terminal and summarize any linked generations."""
+    started = time.monotonic()
+    deadline = started + timeout_sec
+
+    while time.monotonic() <= deadline:
+        task_row = _fetch_task_row(db, task_id, project_id)
+        if task_row is not None and task_row.get("status") in TERMINAL_STATUSES:
+            final_status = str(task_row["status"])
+            generation_ids, generation_location = _fetch_generations_since(
+                db,
+                task_id=task_id,
+                project_id=project_id,
+                task_created_at=task_row.get("created_at"),
+            )
+            output_location = task_row.get("output_location") or generation_location
+            return TaskResult(
+                task_id=task_id,
+                case_name=case_name or task_id,
+                task_type=task_type or str(task_row.get("task_type") or ""),
+                final_status=final_status,
+                output_location=str(output_location) if output_location else None,
+                generation_ids=generation_ids,
+                elapsed_sec=round(time.monotonic() - started, 3),
+                error_summary=_failure_summary(task_row, final_status, generation_ids),
+            )
+
+        time.sleep(interval_sec)
+
+    task_row = _fetch_task_row(db, task_id, project_id)
+    final_status = str(task_row.get("status")) if task_row else "Timed Out"
+    generation_ids, generation_location = _fetch_generations_since(
+        db,
+        task_id=task_id,
+        project_id=project_id,
+        task_created_at=task_row.get("created_at") if task_row else None,
+    )
+    output_location = ((task_row or {}).get("output_location") or generation_location)
+    return TaskResult(
+        task_id=task_id,
+        case_name=case_name or task_id,
+        task_type=task_type or str((task_row or {}).get("task_type") or ""),
+        final_status=final_status,
+        output_location=str(output_location) if output_location else None,
+        generation_ids=generation_ids,
+        elapsed_sec=round(time.monotonic() - started, 3),
+        error_summary=f"Timed out waiting for task {task_id} to reach a terminal state",
+    )
+
+
+__all__ = ["TERMINAL_STATUSES", "TaskResult", "poll_until_complete"]

--- a/scripts/live_test/config.py
+++ b/scripts/live_test/config.py
@@ -1,0 +1,203 @@
+"""Configuration and static references for the live-test harness."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import scripts.live_test as live_test_pkg
+from scripts.live_test import ORCHESTRATOR_ROOT, WORKER_ROOT, ensure_orchestrator_imports
+
+ensure_orchestrator_imports()
+
+
+def _load_env_file(path: Path) -> None:
+    if not path.exists():
+        return
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if value and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        os.environ.setdefault(key, value)
+
+
+_load_env_file(WORKER_ROOT / ".env")
+
+
+def get_env(name: str, default: str | None = None) -> str | None:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    value = value.strip()
+    return value or default
+
+
+def require_env(name: str) -> str:
+    value = get_env(name)
+    if value is None:
+        raise ValueError(f"Missing required environment variable: {name}")
+    return value
+
+
+@dataclass(frozen=True)
+class RunpodDefaults:
+    gpu_type: str
+    worker_image: str
+    template_id: str
+    volume_mount_path: str
+    disk_size_gb: int
+    container_disk_gb: int
+    min_vcpu_count: int
+    min_memory_gb: int
+    storage_volumes: tuple[str, ...]
+    ram_tiers: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class LiveTestEnv:
+    reigh_live_test_token: str | None
+    runpod_api_key: str | None
+    supabase_url: str | None
+    supabase_service_role_key: str | None
+
+
+def _load_runpod_defaults() -> RunpodDefaults:
+    try:
+        from runpod_lifecycle import RunPodConfig
+
+        cfg = RunPodConfig.from_env()
+        return RunpodDefaults(
+            gpu_type=cfg.gpu_type,
+            worker_image=cfg.worker_image,
+            template_id=cfg.template_id,
+            volume_mount_path=cfg.volume_mount_path,
+            disk_size_gb=cfg.disk_size_gb,
+            container_disk_gb=cfg.container_disk_gb,
+            min_vcpu_count=cfg.min_vcpu_count,
+            min_memory_gb=cfg.min_memory_gb,
+            storage_volumes=tuple(cfg.storage_volumes) or (cfg.storage_name,) if cfg.storage_name else tuple(cfg.storage_volumes),
+            ram_tiers=tuple(cfg.ram_tiers),
+        )
+    except Exception:
+        return RunpodDefaults(
+            gpu_type="NVIDIA GeForce RTX 4090",
+            worker_image="runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04",
+            template_id="runpod-torch-v240",
+            volume_mount_path="/workspace",
+            disk_size_gb=50,
+            container_disk_gb=50,
+            min_vcpu_count=8,
+            min_memory_gb=32,
+            storage_volumes=("Peter", "EU-NO-1", "EU-CZ-1", "EUR-IS-1"),
+            ram_tiers=(72, 60, 48, 32, 16),
+        )
+
+
+ENV = LiveTestEnv(
+    reigh_live_test_token=get_env("REIGH_LIVE_TEST_TOKEN"),
+    runpod_api_key=get_env("RUNPOD_API_KEY"),
+    supabase_url=get_env("SUPABASE_URL"),
+    supabase_service_role_key=get_env("SUPABASE_SERVICE_ROLE_KEY"),
+)
+
+RUNPOD = _load_runpod_defaults()
+RUNPOD_GPU_TYPE = RUNPOD.gpu_type
+RUNPOD_WORKER_IMAGE = RUNPOD.worker_image
+RUNPOD_TEMPLATE_ID = RUNPOD.template_id
+RUNPOD_VOLUME_MOUNT_PATH = RUNPOD.volume_mount_path
+LIVE_TEST_CONTAINER_DISK_GB = int(get_env("REIGH_LIVE_TEST_CONTAINER_DISK_GB", "200") or 200)
+LIVE_TEST_DISK_SIZE_GB = int(get_env("REIGH_LIVE_TEST_DISK_SIZE_GB", "200") or 200)
+RUNPOD_DISK_SIZE_GB = RUNPOD.disk_size_gb
+RUNPOD_CONTAINER_DISK_GB = RUNPOD.container_disk_gb
+RUNPOD_MIN_VCPU_COUNT = RUNPOD.min_vcpu_count
+RUNPOD_MIN_MEMORY_GB = RUNPOD.min_memory_gb
+RUNPOD_STORAGE_VOLUMES = RUNPOD.storage_volumes
+RUNPOD_RAM_TIERS = RUNPOD.ram_tiers
+
+TIMEOUT_IMAGE_SEC = 900
+TIMEOUT_INDIVIDUAL_TRAVEL_SEGMENT_SEC = 1500
+TIMEOUT_TRAVEL_ORCHESTRATOR_SEC = 2400
+
+LTX_MODEL_ID = "ltx2_22B_distilled_1_1"
+
+ANCHOR_IMAGE_A_URL = (
+    "https://wczysqzxlwdndgxitrvc.supabase.co/storage/v1/object/public/image_uploads/"
+    "8a9fdac5-ed89-482c-aeca-c3dd7922d53c/41V0rWGAaFwJ4Y9AOqcVC.jpg"
+)
+ANCHOR_IMAGE_B_URL = (
+    "https://wczysqzxlwdndgxitrvc.supabase.co/storage/v1/object/public/image_uploads/"
+    "8a9fdac5-ed89-482c-aeca-c3dd7922d53c/e2699835-35d2-4547-85f5-d59219341e4d-"
+    "u1_3c8779e7-54b4-436c-bfce-9eee8872e370.jpeg"
+)
+
+FIXTURES: dict[str, Path] = {
+    "qwen_image_basic": WORKER_ROOT
+    / "artifacts/worker-matrix/20260316T135006000511Z/qwen_image_basic/prepared_input.json",
+    "qwen_image_edit_basic": WORKER_ROOT
+    / "artifacts/worker-matrix/20260316T135006000511Z/qwen_image_edit_basic/prepared_input.json",
+    "z_image_turbo_i2i_basic": WORKER_ROOT
+    / "artifacts/worker-matrix/20260316T135006000511Z/z_image_turbo_i2i_basic/prepared_input.json",
+    "qwen_image_style_db_task": WORKER_ROOT
+    / "artifacts/worker-matrix/20260316T141738351426Z/qwen_image_style_db_task/prepared_input.json",
+    "wan22_i2v_individual_segment": WORKER_ROOT
+    / "artifacts/worker-matrix/20260316T140127343314Z/wan22_i2v_individual_segment/prepared_input.json",
+}
+
+
+def load_fixture_json(case_name: str) -> dict[str, Any]:
+    fixture_path = FIXTURES[case_name]
+    import json
+
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def __getattr__(name: str):
+    if name in {
+        "DatabaseClient",
+        "RunpodLifecycleMixin",
+        "SSHClient",
+        "get_pod_ssh_details",
+        "terminate_pod",
+    }:
+        return getattr(live_test_pkg, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "ANCHOR_IMAGE_A_URL",
+    "ANCHOR_IMAGE_B_URL",
+    "DatabaseClient",
+    "ENV",
+    "FIXTURES",
+    "LTX_MODEL_ID",
+    "ORCHESTRATOR_ROOT",
+    "RunpodLifecycleMixin",
+    "RUNPOD",
+    "RUNPOD_CONTAINER_DISK_GB",
+    "RUNPOD_DISK_SIZE_GB",
+    "RUNPOD_GPU_TYPE",
+    "RUNPOD_MIN_MEMORY_GB",
+    "RUNPOD_MIN_VCPU_COUNT",
+    "RUNPOD_RAM_TIERS",
+    "RUNPOD_STORAGE_VOLUMES",
+    "RUNPOD_TEMPLATE_ID",
+    "RUNPOD_VOLUME_MOUNT_PATH",
+    "RUNPOD_WORKER_IMAGE",
+    "SSHClient",
+    "TIMEOUT_IMAGE_SEC",
+    "TIMEOUT_INDIVIDUAL_TRAVEL_SEGMENT_SEC",
+    "TIMEOUT_TRAVEL_ORCHESTRATOR_SEC",
+    "WORKER_ROOT",
+    "get_env",
+    "get_pod_ssh_details",
+    "load_fixture_json",
+    "require_env",
+    "terminate_pod",
+]

--- a/scripts/live_test/git_ops.py
+++ b/scripts/live_test/git_ops.py
@@ -1,0 +1,139 @@
+"""Local git snapshot/push/restore helpers for Variant B takeovers."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+PROTECTED_BRANCHES = {"main", "master"}
+
+
+@dataclass(frozen=True)
+class LocalSnapshot:
+    original_branch: str | None
+    original_sha: str
+    is_dirty: bool
+    stash_ref: str | None
+
+
+def _repo_path(submodule_path: str) -> Path:
+    return Path(submodule_path).resolve()
+
+
+def _git(
+    repo_path: Path,
+    *args: str,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_path,
+        check=check,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _find_stash_ref(repo_path: Path, message: str) -> str | None:
+    del message
+    result = _git(repo_path, "stash", "list", "-1", "--format=%gd")
+    ref = result.stdout.strip()
+    return ref or None
+
+
+def snapshot_local_state(submodule_path: str = "reigh-worker") -> LocalSnapshot:
+    repo_path = _repo_path(submodule_path)
+    try:
+        branch = _git(repo_path, "symbolic-ref", "--short", "HEAD").stdout.strip() or None
+    except subprocess.CalledProcessError:
+        branch = None
+
+    original_sha = _git(repo_path, "rev-parse", "HEAD").stdout.strip()
+    status = _git(repo_path, "status", "--porcelain").stdout
+    is_dirty = bool(status.strip())
+    stash_ref = None
+
+    if is_dirty:
+        message = f"live-test-{_timestamp()}"
+        _git(repo_path, "stash", "push", "--include-untracked", "-m", message)
+        stash_ref = _find_stash_ref(repo_path, message)
+        if not stash_ref:
+            raise RuntimeError("Failed to capture stash reference for dirty working tree")
+
+    return LocalSnapshot(
+        original_branch=branch,
+        original_sha=original_sha,
+        is_dirty=is_dirty,
+        stash_ref=stash_ref,
+    )
+
+
+def push_working_copy_to_temp_branch(
+    submodule_path: str,
+    snapshot: LocalSnapshot,
+) -> tuple[str, str]:
+    repo_path = _repo_path(submodule_path)
+    branch_name = f"live-test/{_timestamp()}-{snapshot.original_sha[:8]}"
+    if branch_name in PROTECTED_BRANCHES:
+        raise ValueError(f"Refusing to use protected branch name: {branch_name}")
+
+    _git(repo_path, "checkout", "-b", branch_name)
+
+    if snapshot.is_dirty:
+        if not snapshot.stash_ref:
+            raise RuntimeError("Dirty snapshot is missing stash_ref")
+        _git(repo_path, "stash", "apply", snapshot.stash_ref)
+        _git(repo_path, "add", "-A")
+        commit_status = _git(repo_path, "status", "--porcelain").stdout.strip()
+        if commit_status:
+            _git(repo_path, "commit", "-m", f"live-test: {_timestamp()}")
+
+    _git(repo_path, "push", "-u", "origin", branch_name)
+    current_sha = _git(repo_path, "rev-parse", "HEAD").stdout.strip()
+    return branch_name, current_sha
+
+
+def restore_local_state(submodule_path: str, snapshot: LocalSnapshot) -> None:
+    repo_path = _repo_path(submodule_path)
+    if snapshot.original_branch:
+        _git(repo_path, "checkout", snapshot.original_branch)
+        _git(repo_path, "reset", "--hard", snapshot.original_sha)
+    else:
+        _git(repo_path, "checkout", "--detach", snapshot.original_sha)
+
+    if snapshot.is_dirty:
+        if not snapshot.stash_ref:
+            raise RuntimeError("Dirty snapshot is missing stash_ref during restore")
+        _git(repo_path, "stash", "pop", snapshot.stash_ref)
+
+
+def cleanup_temp_branch(
+    branch: str,
+    *,
+    preserve: bool,
+    submodule_path: str = "reigh-worker",
+) -> str:
+    if preserve:
+        return branch
+
+    repo_path = _repo_path(submodule_path)
+    _git(repo_path, "push", "origin", "--delete", branch)
+    _git(repo_path, "branch", "-D", branch)
+    return branch
+
+
+__all__ = [
+    "LocalSnapshot",
+    "PROTECTED_BRANCHES",
+    "cleanup_temp_branch",
+    "push_working_copy_to_temp_branch",
+    "restore_local_state",
+    "snapshot_local_state",
+]

--- a/scripts/live_test/heartbeat_waiter.py
+++ b/scripts/live_test/heartbeat_waiter.py
@@ -1,0 +1,77 @@
+"""Heartbeat-based readiness detection for live worker tests."""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+
+class WorkerReadyTimeoutError(TimeoutError):
+    """Raised when the worker never establishes a stable heartbeat."""
+
+
+def _coerce_rows(result: Any) -> list[dict[str, Any]]:
+    data = getattr(result, "data", None)
+    if not data:
+        return []
+    if isinstance(data, dict):
+        return [data]
+    return [row for row in data if isinstance(row, dict)]
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    normalized = str(value).replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def wait_until_ready(
+    db,
+    worker_id: str,
+    *,
+    timeout_sec: int = 900,
+    interval_sec: int = 10,
+    dwell_polls: int = 2,
+) -> dict[str, Any]:
+    """Wait until the workers row has a recent heartbeat for N consecutive polls."""
+    if dwell_polls < 1:
+        raise ValueError("dwell_polls must be >= 1")
+
+    deadline = time.monotonic() + timeout_sec
+    consecutive_fresh_polls = 0
+
+    while time.monotonic() < deadline:
+        rows = _coerce_rows(
+            db.supabase.table("workers").select("id, last_heartbeat").eq("id", worker_id).execute()
+        )
+        worker = rows[0] if rows else None
+        last_heartbeat = _parse_timestamp(worker.get("last_heartbeat") if worker else None)
+
+        # Only the startup template writes startup_phase metadata. No code under reigh-worker/source/
+        # updates it, so gating Variant Fresh on startup_phase would make the custom PAT launch path
+        # impossible to satisfy. Heartbeat freshness plus dwell is the reliable signal here.
+        is_fresh = False
+        if last_heartbeat is not None:
+            freshness_cutoff = datetime.now(timezone.utc) - timedelta(seconds=60)
+            is_fresh = last_heartbeat > freshness_cutoff
+
+        if is_fresh:
+            consecutive_fresh_polls += 1
+            if consecutive_fresh_polls >= dwell_polls:
+                return worker or {"id": worker_id, "last_heartbeat": None}
+        else:
+            consecutive_fresh_polls = 0
+
+        time.sleep(interval_sec)
+
+    raise WorkerReadyTimeoutError(
+        f"Worker {worker_id} did not maintain a fresh heartbeat for {dwell_polls} consecutive polls"
+    )
+
+
+__all__ = ["WorkerReadyTimeoutError", "wait_until_ready"]

--- a/scripts/live_test/launch_command.py
+++ b/scripts/live_test/launch_command.py
@@ -1,0 +1,81 @@
+"""Launch-command builders for live worker tests."""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import PurePosixPath
+
+
+def _quote(value: str) -> str:
+    return shlex.quote(value)
+
+
+def _normalize_cli_args(cli_args: list[str]) -> list[str]:
+    normalized = [str(arg) for arg in cli_args if str(arg).strip()]
+    while normalized and normalized[0] == "nohup":
+        normalized = normalized[1:]
+    while normalized and normalized[-1] == "&":
+        normalized = normalized[:-1]
+    return normalized
+
+
+def build_run_worker_command(
+    workdir: str,
+    *,
+    reigh_token: str,
+    supabase_url: str,
+    worker_id: str,
+    wgp_profile: int,
+    idle_release_minutes: int,
+) -> str:
+    workdir_q = _quote(workdir)
+    prefix = [
+        f"cd {workdir_q}",
+        "mkdir -p logs",
+        'export PATH="$HOME/.local/bin:$PATH"',
+    ]
+    worker_parts = [
+        "nohup",
+        "uv",
+        "run",
+        "--python",
+        "3.10",
+        "--extra",
+        "cuda124",
+        "python",
+        "run_worker.py",
+        "--supabase-url",
+        _quote(supabase_url),
+        "--reigh-access-token",
+        _quote(reigh_token),
+        "--worker",
+        _quote(worker_id),
+        "--wgp-profile",
+        str(wgp_profile),
+        "--idle-release-minutes",
+        str(idle_release_minutes),
+        "--save-logging",
+        "logs/worker.log",
+        "</dev/null",
+        ">",
+        "logs/startup.log",
+        "2>&1",
+        "&",
+    ]
+    return " && ".join(prefix) + " && " + " ".join(worker_parts) + " disown"
+
+
+def build_direct_worker_command(workdir: str, *, cli_args: list[str]) -> str:
+    normalized = _normalize_cli_args(cli_args)
+    if not normalized:
+        raise ValueError("cli_args is empty")
+    if not any(arg.endswith("worker.py") or arg == "worker.py" for arg in normalized):
+        raise ValueError("cli_args does not contain worker.py")
+
+    workdir_q = _quote(workdir)
+    rendered_args = " ".join(_quote(arg) for arg in normalized)
+    startup_log = PurePosixPath("logs") / "startup.log"
+    return f"cd {workdir_q} && nohup {rendered_args} > {startup_log} 2>&1 &"
+
+
+__all__ = ["build_direct_worker_command", "build_run_worker_command"]

--- a/scripts/live_test/logger.py
+++ b/scripts/live_test/logger.py
@@ -1,0 +1,51 @@
+"""Small logging shim for the live-test harness."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+
+_CONFIGURED = False
+
+
+def configure_logging(*, level: str = "INFO") -> None:
+    global _CONFIGURED
+    if _CONFIGURED:
+        return
+
+    resolved_level = getattr(logging, level.upper(), logging.INFO)
+    logging.basicConfig(
+        level=resolved_level,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    _CONFIGURED = True
+
+    try:
+        import structlog
+    except ImportError:
+        return
+
+    structlog.configure(
+        wrapper_class=structlog.make_filtering_bound_logger(resolved_level),
+        processors=[
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.add_log_level,
+            structlog.processors.StackInfoRenderer(),
+            structlog.dev.ConsoleRenderer(),
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+
+def get_logger(name: str = "scripts.live_test") -> Any:
+    configure_logging()
+    try:
+        import structlog
+    except ImportError:
+        return logging.getLogger(name)
+    return structlog.get_logger(name)
+
+
+__all__ = ["configure_logging", "get_logger"]

--- a/scripts/live_test/main.py
+++ b/scripts/live_test/main.py
@@ -1,0 +1,73 @@
+"""CLI entrypoint for the live worker harness."""
+
+from __future__ import annotations
+
+import argparse
+
+from scripts.live_test import config
+from scripts.live_test.variant_fresh import run as run_variant_fresh
+from scripts.live_test.variant_update import run as run_variant_update
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the Reigh live worker harness.")
+    parser.add_argument("--variant", choices=("fresh", "update"), required=True)
+    parser.add_argument("--pod-id", help="Existing RunPod pod ID for update-mode takeover.")
+    parser.add_argument(
+        "--spawn-takeover",
+        action="store_true",
+        help="Spawn a fresh orchestrator-managed pod, then take it over with the local worker branch.",
+    )
+    termination_group = parser.add_mutually_exclusive_group()
+    termination_group.add_argument("--no-terminate", dest="no_terminate", action="store_true")
+    termination_group.add_argument("--terminate", dest="no_terminate", action="store_false")
+    parser.set_defaults(no_terminate=None)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--ref", default="main", help="Branch/ref to clone for Variant Fresh.")
+    parser.add_argument("--wgp-profile", type=int, default=3)
+    parser.add_argument("--timeout-image", type=int, default=config.TIMEOUT_IMAGE_SEC)
+    parser.add_argument(
+        "--timeout-travel-segment",
+        type=int,
+        default=config.TIMEOUT_INDIVIDUAL_TRAVEL_SEGMENT_SEC,
+    )
+    parser.add_argument(
+        "--timeout-travel-orchestrator",
+        type=int,
+        default=config.TIMEOUT_TRAVEL_ORCHESTRATOR_SEC,
+    )
+    parser.add_argument("--anchor-image-a", default=config.ANCHOR_IMAGE_A_URL)
+    parser.add_argument("--anchor-image-b", default=config.ANCHOR_IMAGE_B_URL)
+    parser.add_argument(
+        "--serial",
+        action="store_true",
+        help="Reserved for future matrix fan-out; current harness always runs serially.",
+    )
+    return parser
+
+
+def _finalize_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> argparse.Namespace:
+    if args.variant == "fresh":
+        if args.pod_id or args.spawn_takeover:
+            parser.error("--pod-id/--spawn-takeover are only valid with --variant update")
+        if args.no_terminate is None:
+            args.no_terminate = False
+        return args
+
+    if bool(args.pod_id) == bool(args.spawn_takeover):
+        parser.error("update variant requires exactly one of --pod-id or --spawn-takeover")
+    if args.no_terminate is None:
+        args.no_terminate = True
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = _finalize_args(parser.parse_args(argv), parser)
+    if args.variant == "fresh":
+        return run_variant_fresh(args)
+    return run_variant_update(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/live_test/matrix.py
+++ b/scripts/live_test/matrix.py
@@ -1,0 +1,283 @@
+"""Live-test task matrix definitions and execution helpers."""
+
+from __future__ import annotations
+
+import copy
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from scripts.create_test_task import TEST_TASKS
+from scripts.live_test import config
+from scripts.live_test.completion_poller import TaskResult, poll_until_complete
+from scripts.live_test.task_spoofer import insert_spoof_task, load_fixture
+
+
+TRAVEL_WAN_FIXTURE_KEY = "travel_orchestrator_wan2_1seg"
+TRAVEL_LTX_FIXTURE_KEY = "travel_orchestrator_ltx"
+
+
+@dataclass(frozen=True)
+class MatrixCase:
+    name: str
+    task_type: str
+    fixture_key: str
+    param_overrides: dict[str, Any] = field(default_factory=dict)
+    timeout_sec: int = 0
+
+
+def _deep_merge(base: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
+    merged = copy.deepcopy(base)
+    for key, value in (overrides or {}).items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
+def _anchor_pair() -> list[str]:
+    return [config.ANCHOR_IMAGE_A_URL, config.ANCHOR_IMAGE_B_URL]
+
+
+def _build_wan_travel_fixture() -> dict[str, Any]:
+    template = copy.deepcopy(TEST_TASKS["travel_orchestrator"])
+    orchestrator_details = template["params"]["orchestrator_details"]
+    orchestrator_details["input_image_paths_resolved"] = _anchor_pair()
+    orchestrator_details["input_image_generation_ids"] = [
+        "live-test-anchor-a",
+        "live-test-anchor-b",
+    ]
+    orchestrator_details["num_new_segments_to_generate"] = 1
+    orchestrator_details["segment_frames_expanded"] = [65]
+    orchestrator_details["frame_overlap_expanded"] = [10]
+    orchestrator_details["base_prompt"] = "A smooth cinematic move bridging two high-contrast scenes"
+    orchestrator_details["base_prompts_expanded"] = [orchestrator_details["base_prompt"]]
+    orchestrator_details["negative_prompts_expanded"] = [""]
+    orchestrator_details["enhanced_prompts_expanded"] = [""]
+    return template
+
+
+def _build_ltx_travel_fixture() -> dict[str, Any]:
+    template = _build_wan_travel_fixture()
+    orchestrator_details = template["params"]["orchestrator_details"]
+    orchestrator_details["model_name"] = config.LTX_MODEL_ID
+    orchestrator_details["model_type"] = "ltx2"
+    orchestrator_details["parsed_resolution_wh"] = "768x512"
+    orchestrator_details["steps"] = 8
+    orchestrator_details["fps_helpers"] = 24
+    orchestrator_details["guidance_scale"] = 3.0
+    orchestrator_details["num_inference_steps"] = 8
+    orchestrator_details["flow_shift"] = 5
+    orchestrator_details["enhance_prompt"] = False
+    orchestrator_details["frame_overlap_expanded"] = [25]
+    orchestrator_details["travel_guidance"] = {"kind": "none"}
+    orchestrator_details.pop("phase_config", None)
+    orchestrator_details.pop("selected_phase_preset_id", None)
+    return template
+
+
+def resolve_case_fixture(case: MatrixCase) -> dict[str, Any]:
+    if case.fixture_key == TRAVEL_WAN_FIXTURE_KEY:
+        return _build_wan_travel_fixture()
+    if case.fixture_key == TRAVEL_LTX_FIXTURE_KEY:
+        return _build_ltx_travel_fixture()
+    return load_fixture(case.fixture_key)
+
+
+def build_case_params_overrides(
+    case: MatrixCase,
+    *,
+    unique_suffix: str | None = None,
+) -> dict[str, Any]:
+    suffix = unique_suffix or uuid.uuid4().hex[:12]
+    task_marker = f"live-test-{case.name}-{suffix}"
+    runtime: dict[str, Any] = {"task_id": task_marker}
+
+    if case.task_type == "travel_orchestrator":
+        runtime["orchestrator_details"] = {
+            "run_id": task_marker,
+            "orchestrator_task_id": task_marker,
+            "input_image_generation_ids": [
+                f"{task_marker}-anchor-a",
+                f"{task_marker}-anchor-b",
+            ],
+        }
+
+    if case.task_type == "individual_travel_segment":
+        runtime["orchestrator_details"] = {
+            "orchestrator_task_id": f"{task_marker}-parent",
+            "input_image_paths_resolved": _anchor_pair(),
+        }
+        runtime["individual_segment_params"] = {
+            "start_image_url": config.ANCHOR_IMAGE_A_URL,
+            "end_image_url": config.ANCHOR_IMAGE_B_URL,
+            "input_image_paths_resolved": _anchor_pair(),
+        }
+        runtime["start_image_url"] = config.ANCHOR_IMAGE_A_URL
+        runtime["end_image_url"] = config.ANCHOR_IMAGE_B_URL
+        runtime["input_image_paths_resolved"] = _anchor_pair()
+
+    return _deep_merge(case.param_overrides, runtime)
+
+
+def render_case_payload(
+    case: MatrixCase,
+    *,
+    project_id: str,
+    unique_suffix: str | None = None,
+) -> dict[str, Any]:
+    payload = copy.deepcopy(resolve_case_fixture(case))
+    payload.pop("notes", None)
+    payload.pop("description", None)
+    payload["project_id"] = project_id
+    payload["task_type"] = case.task_type
+    payload["status"] = "Queued"
+
+    params = payload.get("params")
+    if not isinstance(params, dict):
+        params = {}
+    payload["params"] = _deep_merge(
+        params,
+        build_case_params_overrides(case, unique_suffix=unique_suffix),
+    )
+    payload["params"]["live_test"] = True
+    return payload
+
+
+def build_matrix(
+    *,
+    anchor_image_a: str = config.ANCHOR_IMAGE_A_URL,
+    anchor_image_b: str = config.ANCHOR_IMAGE_B_URL,
+    timeout_image_sec: int = config.TIMEOUT_IMAGE_SEC,
+    timeout_travel_segment_sec: int = config.TIMEOUT_INDIVIDUAL_TRAVEL_SEGMENT_SEC,
+    timeout_travel_orchestrator_sec: int = config.TIMEOUT_TRAVEL_ORCHESTRATOR_SEC,
+) -> list[MatrixCase]:
+    return [
+        MatrixCase(
+            name="travel_orchestrator_wan2_1seg",
+            task_type="travel_orchestrator",
+            fixture_key=TRAVEL_WAN_FIXTURE_KEY,
+            timeout_sec=timeout_travel_orchestrator_sec,
+        ),
+        MatrixCase(
+            name="travel_orchestrator_ltx",
+            task_type="travel_orchestrator",
+            fixture_key=TRAVEL_LTX_FIXTURE_KEY,
+            timeout_sec=timeout_travel_orchestrator_sec,
+        ),
+        MatrixCase(
+            name="individual_travel_segment",
+            task_type="individual_travel_segment",
+            fixture_key="wan22_i2v_individual_segment",
+            param_overrides={
+                "start_image_url": anchor_image_a,
+                "end_image_url": anchor_image_b,
+                "input_image_paths_resolved": [anchor_image_a, anchor_image_b],
+                "orchestrator_details": {
+                    "input_image_paths_resolved": [anchor_image_a, anchor_image_b],
+                },
+                "individual_segment_params": {
+                    "start_image_url": anchor_image_a,
+                    "end_image_url": anchor_image_b,
+                    "input_image_paths_resolved": [anchor_image_a, anchor_image_b],
+                },
+            },
+            timeout_sec=timeout_travel_segment_sec,
+        ),
+        MatrixCase(
+            name="qwen_image_style",
+            task_type="qwen_image_style",
+            fixture_key="qwen_image_style_db_task",
+            param_overrides={
+                "style_reference_image": anchor_image_a,
+                "subject_reference_image": anchor_image_a,
+            },
+            timeout_sec=timeout_image_sec,
+        ),
+        MatrixCase(
+            name="qwen_image_t2i",
+            task_type="qwen_image",
+            fixture_key="qwen_image_basic",
+            timeout_sec=timeout_image_sec,
+        ),
+        MatrixCase(
+            name="qwen_image_2512",
+            task_type="qwen_image_2512",
+            fixture_key="qwen_image_basic",
+            param_overrides={"resolution": "1536x864"},
+            timeout_sec=timeout_image_sec,
+        ),
+        MatrixCase(
+            name="qwen_image_edit",
+            task_type="qwen_image_edit",
+            fixture_key="qwen_image_edit_basic",
+            param_overrides={
+                "image": anchor_image_b,
+                "image_url": anchor_image_b,
+            },
+            timeout_sec=timeout_image_sec,
+        ),
+        MatrixCase(
+            name="z_image_turbo_i2i",
+            task_type="z_image_turbo_i2i",
+            fixture_key="z_image_turbo_i2i_basic",
+            param_overrides={"image_url": anchor_image_a},
+            timeout_sec=timeout_image_sec,
+        ),
+    ]
+
+
+MATRIX = build_matrix()
+
+
+def run_matrix(db, project_id: str, cases: list[MatrixCase]) -> list[TaskResult]:
+    results: list[TaskResult] = []
+    for case in cases:
+        started = time.monotonic()
+        try:
+            suffix = uuid.uuid4().hex[:12]
+            fixture_payload = resolve_case_fixture(case)
+            overrides = build_case_params_overrides(case, unique_suffix=suffix)
+            task_id = insert_spoof_task(
+                db,
+                project_id,
+                case.task_type,
+                overrides,
+                fixture_payload=fixture_payload,
+            )
+            result = poll_until_complete(
+                db,
+                task_id,
+                project_id,
+                timeout_sec=case.timeout_sec,
+                case_name=case.name,
+                task_type=case.task_type,
+            )
+        except Exception as exc:
+            result = TaskResult(
+                task_id=f"insert-failed:{case.name}",
+                case_name=case.name,
+                task_type=case.task_type,
+                final_status="Insert Failed",
+                output_location=None,
+                generation_ids=[],
+                elapsed_sec=round(time.monotonic() - started, 3),
+                error_summary=str(exc),
+            )
+        results.append(result)
+    return results
+
+
+__all__ = [
+    "MATRIX",
+    "MatrixCase",
+    "TRAVEL_LTX_FIXTURE_KEY",
+    "TRAVEL_WAN_FIXTURE_KEY",
+    "build_case_params_overrides",
+    "build_matrix",
+    "render_case_payload",
+    "resolve_case_fixture",
+    "run_matrix",
+]

--- a/scripts/live_test/preflight.py
+++ b/scripts/live_test/preflight.py
@@ -1,0 +1,82 @@
+"""User-safety checks before the live harness mutates queue state."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+LIVE_TEST_PROJECT_NAME = "live-test"
+
+
+class UnexpectedUserWorkError(RuntimeError):
+    """Raised when the supposedly isolated test user still has live work queued."""
+
+
+def _coerce_rows(result: Any) -> list[dict[str, Any]]:
+    data = getattr(result, "data", None)
+    if not data:
+        return []
+    if isinstance(data, dict):
+        return [data]
+    return [row for row in data if isinstance(row, dict)]
+
+
+def _is_live_test_task(task: dict[str, Any]) -> bool:
+    params = task.get("params")
+    if not isinstance(params, dict):
+        return False
+    return str(params.get("live_test", "false")).lower() == "true"
+
+
+def assert_user_queue_clean(db, user_id: str) -> None:
+    """Abort if the target user has non-live-test queued or in-progress work."""
+    result = (
+        db.supabase.table("tasks")
+        .select("id, status, params, project_id, projects!inner(user_id)")
+        .in_("status", ["Queued", "In Progress"])
+        .eq("projects.user_id", user_id)
+        .execute()
+    )
+    offending_rows = [row for row in _coerce_rows(result) if not _is_live_test_task(row)]
+    if offending_rows:
+        task_ids = ", ".join(str(row.get("id")) for row in offending_rows if row.get("id"))
+        raise UnexpectedUserWorkError(
+            "Unexpected queued or in-progress non-live-test work exists for this user: "
+            f"{task_ids}"
+        )
+
+
+def get_or_create_live_test_project(db, user_id: str) -> str:
+    """Return the dedicated live-test project ID for the target user."""
+    existing = (
+        db.supabase.table("projects")
+        .select("id, created_at")
+        .eq("user_id", user_id)
+        .eq("name", LIVE_TEST_PROJECT_NAME)
+        .order("created_at")
+        .execute()
+    )
+    rows = _coerce_rows(existing)
+    if rows:
+        project_id = rows[0].get("id")
+        if not project_id:
+            raise RuntimeError("Existing live-test project row is missing id")
+        return str(project_id)
+
+    created = (
+        db.supabase.table("projects")
+        .insert({"user_id": user_id, "name": LIVE_TEST_PROJECT_NAME})
+        .execute()
+    )
+    created_rows = _coerce_rows(created)
+    if len(created_rows) != 1 or not created_rows[0].get("id"):
+        raise RuntimeError("Failed to create live-test project")
+    return str(created_rows[0]["id"])
+
+
+__all__ = [
+    "LIVE_TEST_PROJECT_NAME",
+    "UnexpectedUserWorkError",
+    "assert_user_queue_clean",
+    "get_or_create_live_test_project",
+]

--- a/scripts/live_test/report.py
+++ b/scripts/live_test/report.py
@@ -1,0 +1,71 @@
+"""Report writers for live-test matrix runs."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+from scripts.live_test.completion_poller import TaskResult
+
+
+def _is_passing_result(result: TaskResult) -> bool:
+    return result.final_status == "Complete" and bool(result.generation_ids) and not result.error_summary
+
+
+def _render_markdown(results: list[TaskResult], *, variant: str, pod_id: str | None, passed: int) -> str:
+    total = len(results)
+    lines = [
+        "# Live Test Report",
+        "",
+        f"Variant: `{variant}`",
+        f"Pod ID: `{pod_id or 'n/a'}`",
+        f"Summary: `{passed}/{total} passed`",
+        "",
+        "| Case | Task Type | Final Status | Duration (s) | Output | Generation IDs | Error |",
+        "| --- | --- | --- | ---: | --- | --- | --- |",
+    ]
+    for result in results:
+        generation_ids = ", ".join(result.generation_ids) if result.generation_ids else "-"
+        output = result.output_location or "-"
+        error = (result.error_summary or "-").replace("\n", " ")
+        lines.append(
+            f"| {result.case_name} | {result.task_type} | {result.final_status} | "
+            f"{result.elapsed_sec:.3f} | {output} | {generation_ids} | {error} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_report(
+    results: list[TaskResult],
+    variant: str,
+    pod_id: str | None,
+    out_dir,
+) -> Path:
+    output_dir = Path(out_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    passed = sum(1 for result in results if _is_passing_result(result))
+    report_data = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "variant": variant,
+        "pod_id": pod_id,
+        "passed": passed,
+        "total": len(results),
+        "results": [asdict(result) for result in results],
+    }
+
+    (output_dir / "report.json").write_text(
+        json.dumps(report_data, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    (output_dir / "report.md").write_text(
+        _render_markdown(results, variant=variant, pod_id=pod_id, passed=passed),
+        encoding="utf-8",
+    )
+    return output_dir
+
+
+__all__ = ["write_report"]

--- a/scripts/live_test/safety_gate.py
+++ b/scripts/live_test/safety_gate.py
@@ -1,0 +1,78 @@
+"""Takeover safety checks for Variant B live-test runs."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+
+class UnsafeTakeoverError(RuntimeError):
+    """Raised when a pod or user is not safe to take over for live testing."""
+
+
+def _coerce_rows(result: Any) -> list[dict[str, Any]]:
+    data = getattr(result, "data", None)
+    if not data:
+        return []
+    if isinstance(data, dict):
+        return [data]
+    return [row for row in data if isinstance(row, dict)]
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    normalized = str(value).replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def assert_safe_to_take_over(
+    db,
+    pod_id: str,
+    user_id: str,
+    *,
+    allow_fresh_heartbeat: bool = False,
+) -> None:
+    """Reject unsafe takeovers.
+
+    B-existing passes ``allow_fresh_heartbeat=False`` because an active heartbeat on the target pod
+    means someone is already using it. B-fresh-takeover passes ``True`` because the caller owns the
+    newly spawned pod. The PAT-work guard still runs in both modes.
+    """
+    recent_task_cutoff = datetime.now(timezone.utc) - timedelta(seconds=90)
+    recent_user_work = _coerce_rows(
+        db.supabase.table("tasks")
+        .select("id, generation_started_at, status, task_type, project_id, projects!inner(user_id)")
+        .eq("status", "In Progress")
+        .eq("projects.user_id", user_id)
+        .execute()
+    )
+    active_recent_rows = []
+    for row in recent_user_work:
+        started_at = _parse_timestamp(row.get("generation_started_at"))
+        if started_at is not None and started_at > recent_task_cutoff:
+            active_recent_rows.append(row)
+    if active_recent_rows:
+        task_ids = ", ".join(str(row.get("id")) for row in active_recent_rows if row.get("id"))
+        raise UnsafeTakeoverError(
+            "Target user still has fresh in-progress PAT work; refusing takeover. "
+            f"Tasks: {task_ids}"
+        )
+
+    if allow_fresh_heartbeat:
+        return
+
+    worker_rows = _coerce_rows(
+        db.supabase.table("workers").select("id, last_heartbeat").eq("id", pod_id).execute()
+    )
+    worker = worker_rows[0] if worker_rows else None
+    heartbeat = _parse_timestamp(worker.get("last_heartbeat") if worker else None)
+    heartbeat_cutoff = datetime.now(timezone.utc) - timedelta(seconds=60)
+    if heartbeat is not None and heartbeat >= heartbeat_cutoff:
+        raise UnsafeTakeoverError(f"Pod {pod_id} still has a fresh worker heartbeat")
+
+
+__all__ = ["UnsafeTakeoverError", "assert_safe_to_take_over"]

--- a/scripts/live_test/smoke.py
+++ b/scripts/live_test/smoke.py
@@ -1,0 +1,144 @@
+"""No-GPU validation path for the live-test harness."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from scripts.live_test import config
+from scripts.live_test.launch_command import build_direct_worker_command, build_run_worker_command
+from scripts.live_test.matrix import build_matrix, render_case_payload
+from scripts.live_test.preflight import assert_user_queue_clean, get_or_create_live_test_project
+from scripts.live_test.safety_gate import assert_safe_to_take_over
+from scripts.live_test.token_resolver import resolve_token_to_user_id
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Smoke-test the live worker harness without touching RunPod.")
+    parser.add_argument("--pod-id", help="Optional pod ID to run the PAT-aware takeover safety gate against.")
+    parser.add_argument("--skip-db", action="store_true", help="Skip token resolution and Supabase preflight checks.")
+    parser.add_argument(
+        "--require-db",
+        action="store_true",
+        help="Fail instead of degrading to static checks when Supabase preflight cannot run.",
+    )
+    parser.add_argument("--wgp-profile", type=int, default=3)
+    parser.add_argument("--idle-release-minutes", type=int, default=0)
+    parser.add_argument("--worker-id", default="smoke-worker")
+    parser.add_argument("--anchor-image-a", default=config.ANCHOR_IMAGE_A_URL)
+    parser.add_argument("--anchor-image-b", default=config.ANCHOR_IMAGE_B_URL)
+    parser.add_argument("--timeout-image", type=int, default=config.TIMEOUT_IMAGE_SEC)
+    parser.add_argument(
+        "--timeout-travel-segment",
+        type=int,
+        default=config.TIMEOUT_INDIVIDUAL_TRAVEL_SEGMENT_SEC,
+    )
+    parser.add_argument(
+        "--timeout-travel-orchestrator",
+        type=int,
+        default=config.TIMEOUT_TRAVEL_ORCHESTRATOR_SEC,
+    )
+    return parser
+
+
+def _print_case_summary(cases) -> None:
+    print("Validated matrix cases:")
+    for case in cases:
+        print(f"- {case.name} ({case.task_type}, timeout={case.timeout_sec}s)")
+
+
+def _static_validate_cases(cases) -> None:
+    for index, case in enumerate(cases, start=1):
+        payload = render_case_payload(
+            case,
+            project_id="smoke-project",
+            unique_suffix=f"smoke-{index}",
+        )
+        json.dumps(payload)
+        params = payload.get("params", {})
+        if params.get("live_test") is not True:
+            raise RuntimeError(f"{case.name} did not set params.live_test=True")
+        if payload.get("status") != "Queued":
+            raise RuntimeError(f"{case.name} did not render with status='Queued'")
+
+
+def _run_db_checks(pod_id: str | None) -> None:
+    token = config.require_env("REIGH_LIVE_TEST_TOKEN")
+    db = config.DatabaseClient()
+    user_id = resolve_token_to_user_id(db, token)
+    assert_user_queue_clean(db, user_id)
+    project_id = get_or_create_live_test_project(db, user_id)
+    print(f"Resolved REIGH_LIVE_TEST_TOKEN to user_id={user_id}")
+    print(f"Using live-test project_id={project_id}")
+    if pod_id:
+        assert_safe_to_take_over(db, pod_id, user_id, allow_fresh_heartbeat=False)
+        print(f"Safety gate passed for pod_id={pod_id}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    token = config.require_env("REIGH_LIVE_TEST_TOKEN")
+    supabase_url = config.get_env("SUPABASE_URL", "https://example.supabase.co")
+
+    cases = build_matrix(
+        anchor_image_a=args.anchor_image_a,
+        anchor_image_b=args.anchor_image_b,
+        timeout_image_sec=args.timeout_image,
+        timeout_travel_segment_sec=args.timeout_travel_segment,
+        timeout_travel_orchestrator_sec=args.timeout_travel_orchestrator,
+    )
+    _static_validate_cases(cases)
+    _print_case_summary(cases)
+
+    print("")
+    print("Run-worker launch command:")
+    print(
+        build_run_worker_command(
+            "/workspace/Reigh-Worker-LiveTest",
+            reigh_token=token,
+            supabase_url=supabase_url,
+            worker_id=args.worker_id,
+            wgp_profile=args.wgp_profile,
+            idle_release_minutes=args.idle_release_minutes,
+        )
+    )
+    print("")
+    print("Direct-worker restore command:")
+    print(
+        build_direct_worker_command(
+            "/workspace/Reigh-Worker",
+            cli_args=["python", "worker.py", "--task-id", "smoke-task", "--gpu-id", "0"],
+        )
+    )
+
+    if args.skip_db:
+        return 0
+
+    if not (config.ENV.supabase_url and config.ENV.supabase_service_role_key):
+        if args.require_db or args.pod_id:
+            raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required for DB-backed smoke checks")
+        print("")
+        print("Skipping DB-backed smoke checks because Supabase credentials are not set.")
+        return 0
+
+    try:
+        print("")
+        _run_db_checks(args.pod_id)
+    except Exception as exc:
+        if args.require_db or args.pod_id:
+            raise
+        print("")
+        print(f"Skipping DB-backed smoke checks after failure: {exc}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"Smoke check failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/live_test/ssh_bootstrap.py
+++ b/scripts/live_test/ssh_bootstrap.py
@@ -1,0 +1,244 @@
+"""SSH-side worker bootstrap helpers shared by the live-test variants."""
+
+from __future__ import annotations
+
+import shlex
+import time
+from dataclasses import dataclass
+from typing import Literal
+
+import scripts.live_test as live_test_pkg
+
+
+APT_INSTALL_PACKAGES = (
+    "python3.10-venv",
+    "python3.10-dev",
+    "build-essential",
+    "ffmpeg",
+    "git",
+    "curl",
+    "wget",
+)
+PROCESS_SCAN_COMMAND = (
+    r"ps -eo pid=,args= | grep -E '(run_worker\.py|worker\.py|source\.runtime\.worker)' | grep -v grep"
+)
+KILL_COMMAND = (
+    "pkill -f run_worker.py; "
+    "pkill -f 'python worker.py'; "
+    "pkill -f 'source.runtime.worker'; "
+    "sleep 2"
+)
+
+
+@dataclass(frozen=True)
+class WorkerProcessInfo:
+    family: Literal["supervisor", "direct"]
+    cmdline: list[str]
+    pid: int
+
+
+def _quote(value: str) -> str:
+    return shlex.quote(str(value))
+
+
+def _execute(ssh, command: str, *, timeout: int = 600, check: bool = True) -> tuple[str, str]:
+    exit_code, stdout, stderr = ssh.execute_command(command, timeout=timeout)
+    if check and exit_code != 0:
+        raise RuntimeError(
+            f"Remote command failed with exit {exit_code}: {command}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        )
+    return stdout, stderr
+
+
+def open_session(pod_id: str, api_key: str, *, ssh_wait_timeout: int = 300, poll_interval: int = 5):
+    deadline = time.monotonic() + ssh_wait_timeout
+    ssh_details = None
+    while time.monotonic() < deadline:
+        ssh_details = live_test_pkg.get_pod_ssh_details(pod_id, api_key)
+        if ssh_details and ssh_details.get("ip") and ssh_details.get("port"):
+            break
+        time.sleep(poll_interval)
+    if not ssh_details or not ssh_details.get("ip") or not ssh_details.get("port"):
+        raise RuntimeError(
+            f"Could not resolve SSH details for pod {pod_id} within {ssh_wait_timeout}s"
+        )
+
+    import os as _os
+    private_key_path = _os.environ.get("REIGH_LIVE_TEST_SSH_KEY") or "~/.ssh/id_ed25519"
+    ssh = live_test_pkg.SSHClient(
+        hostname=str(ssh_details["ip"]),
+        port=int(ssh_details["port"]),
+        username="root",
+        password=ssh_details.get("password"),
+        private_key_path=private_key_path,
+    )
+    connect_deadline = time.monotonic() + ssh_wait_timeout
+    last_err: Exception | None = None
+    while time.monotonic() < connect_deadline:
+        try:
+            ssh.connect()
+            return ssh
+        except Exception as exc:
+            last_err = exc
+            time.sleep(poll_interval)
+    raise RuntimeError(f"Could not SSH into pod {pod_id} within {ssh_wait_timeout}s: {last_err}")
+
+
+def clone_repo_into(ssh, workdir: str, repo_url: str, branch: str) -> None:
+    parent = workdir.rsplit("/", 1)[0] or "/"
+    command = (
+        f"mkdir -p {_quote(parent)} && "
+        f"rm -rf {_quote(workdir)} && "
+        f"git clone --branch {_quote(branch)} --single-branch --recurse-submodules {_quote(repo_url)} {_quote(workdir)}"
+    )
+    _execute(ssh, command, timeout=1800)
+
+
+def run_install(ssh, workdir: str) -> None:
+    package_list = " ".join(APT_INSTALL_PACKAGES)
+    command = (
+        "bash -lc "
+        + _quote(
+            "set -euo pipefail\n"
+            "apt-get update\n"
+            f"apt-get install -y {package_list}\n"
+            "if ! command -v uv >/dev/null 2>&1; then\n"
+            "  curl -LsSf https://astral.sh/uv/install.sh | sh\n"
+            "  export PATH=\"$HOME/.local/bin:$PATH\"\n"
+            "fi\n"
+            f"cd {shlex.quote(workdir)}\n"
+            "export PATH=\"$HOME/.local/bin:$PATH\"\n"
+            "uv sync --locked --extra cuda124\n"
+        )
+    )
+    _execute(ssh, command, timeout=3600)
+
+
+def export_env(env: dict[str, str]) -> str:
+    exports = dict(env)
+    required = {
+        "REIGH_ACCESS_TOKEN",
+        "SUPABASE_SERVICE_ROLE_KEY",
+        "SUPABASE_URL",
+        "WORKER_DB_CLIENT_AUTH_MODE",
+    }
+    missing = sorted(name for name in required if not exports.get(name))
+    if missing:
+        raise ValueError(f"Missing required environment values for export_env: {', '.join(missing)}")
+    if exports["WORKER_DB_CLIENT_AUTH_MODE"] != "worker":
+        raise ValueError("WORKER_DB_CLIENT_AUTH_MODE must be 'worker' for PAT live tests")
+    return " && ".join(f"export {key}={_quote(value)}" for key, value in sorted(exports.items()))
+
+
+def capture_current_worker_cmdline(ssh) -> WorkerProcessInfo | None:
+    stdout, _ = _execute(ssh, PROCESS_SCAN_COMMAND, check=False)
+    rows: list[tuple[int, list[str]]] = []
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            continue
+        pid_str, args = parts
+        try:
+            pid = int(pid_str)
+        except ValueError:
+            continue
+        rows.append((pid, shlex.split(args)))
+
+    supervisor_rows = [row for row in rows if any("run_worker.py" in arg for arg in row[1])]
+    if supervisor_rows:
+        pid, cmdline = supervisor_rows[0]
+        return WorkerProcessInfo(family="supervisor", cmdline=cmdline, pid=pid)
+
+    direct_rows = [
+        row
+        for row in rows
+        if any(arg == "worker.py" or arg.endswith("/worker.py") or "source.runtime.worker" in arg for arg in row[1])
+    ]
+    if direct_rows:
+        pid, cmdline = direct_rows[0]
+        return WorkerProcessInfo(family="direct", cmdline=cmdline, pid=pid)
+
+    return None
+
+
+def kill_supervisor_and_worker(ssh) -> None:
+    _execute(ssh, KILL_COMMAND, check=False, timeout=30)
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        stdout, _ = _execute(
+            ssh,
+            "pgrep -af run_worker.py || true; "
+            "pgrep -af 'python worker.py' || true; "
+            "pgrep -af source.runtime.worker || true",
+            check=False,
+            timeout=30,
+        )
+        if not stdout.strip():
+            return
+        time.sleep(1)
+    raise RuntimeError(f"Worker processes are still running after kill attempt:\n{stdout}")
+
+
+def launch_worker_detached(ssh, command_line: str) -> None:
+    # Wrap so bash exits immediately after backgrounding; avoid paramiko hanging
+    # on stdout EOF when a nohup child inherits the ssh channel streams.
+    wrapped = f"bash -c {shlex.quote(command_line + ' ; exit 0')} </dev/null >/dev/null 2>&1"
+    client = ssh.client
+    transport = client.get_transport()
+    channel = transport.open_session()
+    try:
+        channel.set_combine_stderr(True)
+        channel.exec_command(wrapped)
+        deadline = time.monotonic() + 30
+        while not channel.exit_status_ready() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        if not channel.exit_status_ready():
+            return  # detached; don't wait further
+        exit_code = channel.recv_exit_status()
+        if exit_code != 0:
+            raise RuntimeError(f"Detached launch command exited with {exit_code}")
+    finally:
+        channel.close()
+
+
+def fetch_worker_logs(ssh, workdir: str, lines: int = 300) -> str:
+    startup_script = _quote(
+        f"cd {workdir} && "
+        f'{{ echo "=== startup.log ==="; tail -n {int(lines)} logs/startup.log 2>/dev/null || true; }}'
+    )
+    startup_stdout, _ = _execute(
+        ssh,
+        f"bash -lc {startup_script}",
+        check=False,
+        timeout=60,
+    )
+    worker_script = _quote(
+        f"cd {workdir} && "
+        f'{{ echo "=== worker.log ==="; tail -n {int(lines)} logs/worker.log 2>/dev/null || true; }}'
+    )
+    worker_stdout, _ = _execute(
+        ssh,
+        f"bash -lc {worker_script}",
+        check=False,
+        timeout=60,
+    )
+    return "\n".join(part.rstrip() for part in (startup_stdout, worker_stdout) if part.strip())
+
+
+__all__ = [
+    "APT_INSTALL_PACKAGES",
+    "KILL_COMMAND",
+    "PROCESS_SCAN_COMMAND",
+    "WorkerProcessInfo",
+    "capture_current_worker_cmdline",
+    "clone_repo_into",
+    "export_env",
+    "fetch_worker_logs",
+    "kill_supervisor_and_worker",
+    "launch_worker_detached",
+    "open_session",
+    "run_install",
+]

--- a/scripts/live_test/stage1_findings.md
+++ b/scripts/live_test/stage1_findings.md
@@ -1,0 +1,128 @@
+# Stage 1 Findings
+
+## Live schema / auth probes
+
+- `user_api_tokens` repo evidence points to a plain `token` column, not `jti_hash`.
+  - Migration [reigh-app/supabase/migrations/20250713000008_fix_user_api_tokens_structure.sql](/Users/peteromalley/Documents/reigh-workspace/reigh-app/supabase/migrations/20250713000008_fix_user_api_tokens_structure.sql:10) drops `jti_hash`, recreates `idx_user_api_tokens_token`, and makes `verify_api_token()` match on `token`.
+  - Generated types [reigh-app/src/integrations/supabase/types.ts](/Users/peteromalley/Documents/reigh-workspace/reigh-app/src/integrations/supabase/types.ts:1314) expose `user_api_tokens.Row` with `token`, `user_id`, `label`, `created_at`, and no `jti_hash`.
+  - Edge auth lookup [reigh-app/supabase/functions/_shared/auth.ts](/Users/peteromalley/Documents/reigh-workspace/reigh-app/supabase/functions/_shared/auth.ts:136) resolves PATs with `.select("user_id").eq("token", token).single()`.
+- Worker claim auth can be forced onto the PAT path while still keeping the service-role key available for heartbeat RPCs.
+  - `_resolve_worker_db_client_key()` in [reigh-worker/source/runtime/worker/server.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/source/runtime/worker/server.py:47) returns the PAT when `WORKER_DB_CLIENT_AUTH_MODE=worker`; service-role auth is only chosen when `WORKER_DB_CLIENT_AUTH_MODE=service`.
+  - Heartbeat guardian auth resolves through edge-token helpers in [reigh-worker/source/task_handlers/worker/heartbeat_utils.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/source/task_handlers/worker/heartbeat_utils.py:13), so injecting `SUPABASE_SERVICE_ROLE_KEY` remains useful even when task claims stay PAT-backed.
+- Probe script added at [reigh-worker/scripts/live_test/stage1_probe.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/scripts/live_test/stage1_probe.py:1).
+  - It loads `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` from the worker repo `.env` if needed.
+  - It requires `REIGH_LIVE_TEST_TOKEN` from env, and falls back to an interactive hidden prompt if stdin is a TTY so the token does not need to be written to disk.
+  - It probes live schema shape by confirming `select=token` works and `select=jti_hash` fails, resolves the live token to exactly one `user_id`, then dumps non-`live_test` queued / in-progress tasks for that user.
+
+## No `startup_phase` writers in worker source
+
+- `rg -n "startup_phase" reigh-worker/source` returned zero matches.
+- The only writer found in this workspace is the orchestrator startup template:
+  - [reigh-worker-orchestrator/gpu_orchestrator/runpod/worker_startup.template.sh](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/runpod/worker_startup.template.sh:45) documents the metadata merge.
+  - [reigh-worker-orchestrator/gpu_orchestrator/runpod/worker_startup.template.sh](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/runpod/worker_startup.template.sh:87) sets `meta['startup_phase']`.
+- Consequence for later tasks: readiness must key off heartbeat freshness plus dwell, not `startup_phase` or `ready_for_tasks`.
+  - `ready_for_tasks` exists only as derived metadata in [reigh-worker-orchestrator/gpu_orchestrator/worker_state.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/worker_state.py:160) and is explicitly still TODO-gated for promotion logic at [worker_state.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/worker_state.py:260).
+
+## RunPod lifecycle / caller sequence
+
+- `RunpodLifecycleMixin.spawn_worker()` exact signature is `spawn_worker(self, worker_id: str, worker_env: Optional[Dict[str, str]] = None) -> Optional[Dict[str, Any]]` in [reigh-worker-orchestrator/gpu_orchestrator/runpod/lifecycle.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/runpod/lifecycle.py:28).
+  - It calls `create_pod_and_wait(...)` with `gpu_type_id`, `image_name`, `name`, `network_volume_id`, `volume_mount_path`, `disk_in_gb`, `container_disk_in_gb`, `min_vcpu_count`, `min_memory_in_gb`, `public_key_string`, `env_vars`, and `template_id` at [lifecycle.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/runpod/lifecycle.py:92).
+  - On success it returns a dict containing both `worker_id` and distinct `runpod_id` at [lifecycle.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/runpod/lifecycle.py:113).
+- `RunpodLifecycleMixin.start_worker_process()` exact signature is `start_worker_process(self, runpod_id: str, worker_id: str, has_pending_tasks: bool = False) -> bool` in [reigh-worker-orchestrator/gpu_orchestrator/runpod/lifecycle.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/runpod/lifecycle.py:148).
+- Caller sequence is explicitly split across the control loop and worker-capacity phase:
+  - The main control loop reaches scaling at [reigh-worker-orchestrator/gpu_orchestrator/control_loop.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/control_loop.py:128) and invokes `_execute_scaling(...)` at [control_loop.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/control_loop.py:131).
+  - `_execute_scaling()` decides to spawn and calls `_spawn_worker(...)` at [reigh-worker-orchestrator/gpu_orchestrator/control/phases/worker_capacity.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/control/phases/worker_capacity.py:115).
+  - `_spawn_worker()` generates `worker_id = self.runpod.generate_worker_id()` at [worker_capacity.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/control/phases/worker_capacity.py:188).
+  - It creates the workers row first via `await self.db.create_worker_record(worker_id, self.runpod.gpu_type)` at [worker_capacity.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/control/phases/worker_capacity.py:190).
+  - It provisions the pod separately with `result = self.runpod.spawn_worker(worker_id)` at [worker_capacity.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/control/phases/worker_capacity.py:193).
+  - It only calls `self.runpod.start_worker_process(pod_id, worker_id, has_pending_tasks=(queued_count > 0))` afterward, and only when `final_status == "active"` plus `auto_start_worker_process` are both true, at [worker_capacity.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/control/phases/worker_capacity.py:233).
+- Accepted-tradeoff confirmation for later `B-fresh-takeover`: `spawn_worker()` does not itself call `start_worker_process()`, and the identifiers stay distinct (`worker_id` vs `runpod_id`).
+
+## RunPod client defaults captured from source
+
+- `RUNPOD_GPU_TYPE` default: `"NVIDIA GeForce RTX 4090"` in [reigh-worker-orchestrator/gpu_orchestrator/runpod/client.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/runpod/client.py:28).
+- `RUNPOD_WORKER_IMAGE` default: `"runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04"` in [client.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/runpod/client.py:29).
+- `RUNPOD_TEMPLATE_ID` default: `"runpod-torch-v240"` in [client.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/runpod/client.py:33).
+- Storage / RAM defaults:
+  - Volume mount path `/workspace`, disk `50 GB`, container disk `50 GB`, min vCPU `8`, min memory `32 GB`, max task wait `5 minutes` at [client.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/runpod/client.py:35).
+  - Storage fallback list `["Peter", "EU-NO-1", "EU-CZ-1", "EUR-IS-1"]` at [client.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/runpod/client.py:42).
+  - RAM fallback tiers `[72, 60, 48, 32, 16]` with `RUNPOD_RAM_TIER_FALLBACK=true` by default at [client.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/runpod/client.py:44).
+
+## Template install / launch facts
+
+- Startup template install path:
+  - Repo selection / clone happens at [reigh-worker-orchestrator/gpu_orchestrator/runpod/worker_startup.template.sh](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/runpod/worker_startup.template.sh:167). It prefers `/workspace/Reigh-Worker`, falls back to `/workspace/Headless-Wan2GP`, otherwise clones `https://github.com/banodoco/Reigh-Worker.git` into `/workspace/Reigh-Worker`.
+  - Apt bootstrap is `apt-get update` plus `apt-get install -y python3.10-venv ffmpeg git curl wget` at [worker_startup.template.sh](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/runpod/worker_startup.template.sh:200).
+  - `uv` bootstrap / sync is `curl -LsSf https://astral.sh/uv/install.sh | sh`, then `"$UV_BIN" sync --locked --python 3.10 --extra cuda124` at [worker_startup.template.sh](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/runpod/worker_startup.template.sh:283).
+- Direct worker launch shape is captured at [worker_startup.template.sh](/Users/peteromalley/Documents/reigh-workspace/reigh-worker-orchestrator/gpu_orchestrator/runpod/worker_startup.template.sh:355):
+  - `"$UV_BIN" run --python 3.10 --extra cuda124 python worker.py`
+  - `--supabase-url "$SUPABASE_URL"`
+  - `--supabase-access-token "$SUPABASE_SERVICE_ROLE_KEY"`
+  - `--worker "$WORKER_ID"`
+  - `--wgp-profile 1`
+
+## Canonical `run_worker.py` argv order
+
+- The app-side launch builder is the authoritative source for the supervisor path:
+  - `buildWorkerLaunchLine()` in [reigh-app/src/shared/components/SettingsModal/commandUtils.ts](/Users/peteromalley/Documents/reigh-workspace/reigh-app/src/shared/components/SettingsModal/commandUtils.ts:58) emits `python run_worker.py`.
+  - Flag order is pinned as `--reigh-access-token`, optional `--debug`, `--wgp-profile`, then `--idle-release-minutes` at [commandUtils.ts](/Users/peteromalley/Documents/reigh-workspace/reigh-app/src/shared/components/SettingsModal/commandUtils.ts:60).
+  - The Linux install/run wrapper uses `uv run --python 3.10 --extra <cuda> ...` at [commandUtils.ts](/Users/peteromalley/Documents/reigh-workspace/reigh-app/src/shared/components/SettingsModal/commandUtils.ts:69) and `uv sync --locked --python 3.10 --extra <cuda>` at [commandUtils.ts](/Users/peteromalley/Documents/reigh-workspace/reigh-app/src/shared/components/SettingsModal/commandUtils.ts:91).
+
+## LTX model pick
+
+- Source evidence says several LTX IDs are available:
+  - Task-type default `ltx2 -> ltx2_19B` is in [reigh-worker/source/task_handlers/tasks/task_types.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/source/task_handlers/tasks/task_types.py:101).
+  - The worker matrix already exercises `ltx2_22B` and `ltx2_22B_distilled` in [reigh-worker/scripts/run_worker_matrix.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/scripts/run_worker_matrix.py:655).
+  - Distilled LTX-2 models are the ones that unlock `ltx_control`, `ltx_hybrid`, and `uni3c` travel-guidance kinds per [reigh-worker/source/core/params/travel_guidance.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/source/core/params/travel_guidance.py:36), because non-distilled LTX returns only `{"none"}`.
+  - `ltx2_22B_distilled` is a first-class model definition with `ltx2_pipeline: "distilled"` in [reigh-worker/Wan2GP/defaults/ltx2_22B_distilled.json](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/Wan2GP/defaults/ltx2_22B_distilled.json:3).
+- Recommendation for the later travel-orchestrator LTX case: use `ltx2_22B_distilled`.
+  - Rationale: it is supported by the checked-in model registry and is the safest LTX choice if the travel path ends up touching any non-`none` guidance mode.
+
+## Fixture inventory for the later live matrix
+
+- The five requested worker-matrix cases exist, each with `case_definition.json`, `prepared_input.json`, `captured_generation_task.json`, and `result.json`.
+  - `qwen_image_basic`: [case_definition.json](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/artifacts/worker-matrix/20260316T135006000511Z/qwen_image_basic/case_definition.json:1), [prepared_input.json](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/artifacts/worker-matrix/20260316T135006000511Z/qwen_image_basic/prepared_input.json:1)
+  - `qwen_image_edit_basic`: [case_definition.json](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/artifacts/worker-matrix/20260316T135006000511Z/qwen_image_edit_basic/case_definition.json:1), [prepared_input.json](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/artifacts/worker-matrix/20260316T135006000511Z/qwen_image_edit_basic/prepared_input.json:1)
+  - `z_image_turbo_i2i_basic`: [case_definition.json](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/artifacts/worker-matrix/20260316T135006000511Z/z_image_turbo_i2i_basic/case_definition.json:1), [prepared_input.json](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/artifacts/worker-matrix/20260316T135006000511Z/z_image_turbo_i2i_basic/prepared_input.json:1)
+  - `qwen_image_style_db_task`: [case_definition.json](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/artifacts/worker-matrix/20260316T141738351426Z/qwen_image_style_db_task/case_definition.json:1), [prepared_input.json](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/artifacts/worker-matrix/20260316T141738351426Z/qwen_image_style_db_task/prepared_input.json:1)
+  - `wan22_i2v_individual_segment`: [case_definition.json](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/artifacts/worker-matrix/20260316T140127343314Z/wan22_i2v_individual_segment/case_definition.json:1), [prepared_input.json](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/artifacts/worker-matrix/20260316T140127343314Z/wan22_i2v_individual_segment/prepared_input.json:1)
+- Snapshot highlights from the prepared inputs:
+  - `qwen_image_basic` params: `seed`, `prompt`, `resolution`, `num_inference_steps`, `task_id`.
+  - `qwen_image_edit_basic` params add `image`.
+  - `z_image_turbo_i2i_basic` params include `image_url` and `denoising_strength`.
+  - `qwen_image_style_db_task` params include `style_reference_image`, `subject_reference_image`, `style_reference_strength`, `subject_strength`, and `subject_description`.
+  - `wan22_i2v_individual_segment` params include `model_name`, `parsed_resolution_wh`, `individual_segment_params`, `orchestrator_details`, and `input_image_paths_resolved`.
+
+## Task-type verification
+
+- [reigh-worker/source/task_handlers/tasks/task_types.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/source/task_handlers/tasks/task_types.py:26) includes:
+  - `z_image_turbo_i2i` in `WGP_TASK_TYPES`
+  - `qwen_image_style` and `qwen_image_2512` in both `WGP_TASK_TYPES` / `DIRECT_QUEUE_TASK_TYPES`
+  - `z_image_turbo_i2i` maps to the `_i2i` model entry at [task_types.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/source/task_handlers/tasks/task_types.py:116)
+
+## Travel templates to reuse later
+
+- `scripts/create_test_task.py` already contains reusable template payloads for:
+  - `travel_orchestrator` at [reigh-worker/scripts/create_test_task.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/scripts/create_test_task.py:324)
+  - `qwen_image_style` at [create_test_task.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/scripts/create_test_task.py:472)
+  - `individual_travel_segment` via the `uni3c_basic` template at [create_test_task.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/scripts/create_test_task.py:26)
+- `scripts/preview/fixtures.py` already wraps those templates into preview-ready task payloads:
+  - `travel_orchestrator` builder at [reigh-worker/scripts/preview/fixtures.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/scripts/preview/fixtures.py:55)
+  - `individual_travel_segment` builder at [fixtures.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/scripts/preview/fixtures.py:109)
+  - `qwen_image` builder at [fixtures.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/scripts/preview/fixtures.py:122)
+
+## Default anchor-image picks for later config
+
+- Proposed default anchor image A:
+  - `https://wczysqzxlwdndgxitrvc.supabase.co/storage/v1/object/public/image_uploads/8a9fdac5-ed89-482c-aeca-c3dd7922d53c/41V0rWGAaFwJ4Y9AOqcVC.jpg`
+  - Reason: already used repeatedly as a travel start image in [reigh-worker/scripts/create_test_task.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/scripts/create_test_task.py:84) and [create_test_task.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/scripts/create_test_task.py:107), so it is already in the repo’s happy-path fixtures.
+- Proposed default anchor image B:
+  - `https://wczysqzxlwdndgxitrvc.supabase.co/storage/v1/object/public/image_uploads/8a9fdac5-ed89-482c-aeca-c3dd7922d53c/e2699835-35d2-4547-85f5-d59219341e4d-u1_3c8779e7-54b4-436c-bfce-9eee8872e370.jpeg`
+  - Reason: paired with anchor A throughout the individual-travel templates at [create_test_task.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/scripts/create_test_task.py:85) and [create_test_task.py](/Users/peteromalley/Documents/reigh-workspace/reigh-worker/scripts/create_test_task.py:108), making it the lowest-risk default pair for the first harness pass.
+
+## Live probe execution note
+
+- I attempted to run `python3 scripts/live_test/stage1_probe.py` interactively from `reigh-worker/` with the provided live token supplied through the hidden prompt.
+- The script reached the network call and failed read-only with:
+  - `ERROR: Network error for /rest/v1/user_api_tokens: <urlopen error [Errno 8] nodename nor servname provided, or not known>`
+- Interpretation: the probe logic is in place, but this sandbox currently cannot resolve / reach Supabase, so the live `user_id` resolution and stray-task dump remain blocked at execution time rather than by missing code.

--- a/scripts/live_test/stage1_probe.py
+++ b/scripts/live_test/stage1_probe.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Stage 1 read-only probes for the live worker harness plan."""
+
+from __future__ import annotations
+
+import getpass
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+class ProbeError(RuntimeError):
+    """Raised when a stage-1 probe fails."""
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_env_file(path: Path) -> None:
+    if not path.exists():
+        return
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if value and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        os.environ.setdefault(key, value)
+
+
+def load_environment() -> None:
+    _load_env_file(REPO_ROOT / ".env")
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if value:
+        return value
+    raise ProbeError(f"Missing required environment variable: {name}")
+
+
+def get_live_test_token() -> str:
+    token = os.environ.get("REIGH_LIVE_TEST_TOKEN", "").strip()
+    if token:
+        return token
+    if sys.stdin.isatty():
+        token = getpass.getpass("REIGH_LIVE_TEST_TOKEN: ").strip()
+        if token:
+            return token
+    raise ProbeError("REIGH_LIVE_TEST_TOKEN is not set")
+
+
+def _request_json(path: str, params: dict[str, str]) -> Any:
+    supabase_url = require_env("SUPABASE_URL").rstrip("/")
+    service_key = require_env("SUPABASE_SERVICE_ROLE_KEY")
+    query = urllib.parse.urlencode(params)
+    url = f"{supabase_url}{path}?{query}"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {service_key}",
+            "apikey": service_key,
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = response.read().decode("utf-8")
+            return json.loads(payload) if payload else None
+    except urllib.error.HTTPError as exc:
+        payload = exc.read().decode("utf-8", errors="replace")
+        message = payload or str(exc)
+        raise ProbeError(f"{exc.code} for {path}: {message}") from exc
+    except urllib.error.URLError as exc:
+        raise ProbeError(f"Network error for {path}: {exc}") from exc
+
+
+def _request_json_allow_http_error(path: str, params: dict[str, str]) -> tuple[int, Any]:
+    supabase_url = require_env("SUPABASE_URL").rstrip("/")
+    service_key = require_env("SUPABASE_SERVICE_ROLE_KEY")
+    query = urllib.parse.urlencode(params)
+    url = f"{supabase_url}{path}?{query}"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {service_key}",
+            "apikey": service_key,
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = response.read().decode("utf-8")
+            return response.status, json.loads(payload) if payload else None
+    except urllib.error.HTTPError as exc:
+        payload = exc.read().decode("utf-8", errors="replace")
+        parsed: Any
+        try:
+            parsed = json.loads(payload) if payload else None
+        except json.JSONDecodeError:
+            parsed = payload
+        return exc.code, parsed
+
+
+def assert_user_api_token_shape() -> dict[str, Any]:
+    token_rows = _request_json(
+        "/rest/v1/user_api_tokens",
+        {
+            "select": "token,user_id",
+            "limit": "1",
+        },
+    )
+    if not isinstance(token_rows, list):
+        raise ProbeError("Expected list response when checking user_api_tokens.token")
+
+    jti_status, jti_payload = _request_json_allow_http_error(
+        "/rest/v1/user_api_tokens",
+        {
+            "select": "jti_hash",
+            "limit": "1",
+        },
+    )
+    if jti_status == 200:
+        raise ProbeError("user_api_tokens.jti_hash still exists in the live schema")
+
+    payload_text = json.dumps(jti_payload).lower()
+    if jti_status not in {400, 404} or "jti_hash" not in payload_text:
+        raise ProbeError(
+            f"Unexpected response when checking jti_hash absence: status={jti_status} payload={jti_payload!r}"
+        )
+
+    return {
+        "token_select_status": "ok",
+        "token_probe_rows": len(token_rows),
+        "jti_hash_status": jti_status,
+        "jti_hash_payload": jti_payload,
+    }
+
+
+def resolve_token_to_user_id(token: str) -> str:
+    rows = _request_json(
+        "/rest/v1/user_api_tokens",
+        {
+            "select": "user_id",
+            "token": f"eq.{token}",
+        },
+    )
+    if not isinstance(rows, list):
+        raise ProbeError("Expected list response when resolving REIGH_LIVE_TEST_TOKEN")
+    if len(rows) != 1:
+        raise ProbeError(f"Expected exactly one user_api_tokens row for the live token, got {len(rows)}")
+    user_id = rows[0].get("user_id")
+    if not user_id:
+        raise ProbeError("Resolved token row is missing user_id")
+    return str(user_id)
+
+
+def load_projects_for_user(user_id: str) -> list[dict[str, Any]]:
+    rows = _request_json(
+        "/rest/v1/projects",
+        {
+            "select": "id,name,user_id,created_at",
+            "user_id": f"eq.{user_id}",
+            "order": "created_at.asc",
+        },
+    )
+    if not isinstance(rows, list):
+        raise ProbeError("Expected list response when loading user projects")
+    return rows
+
+
+def _load_tasks_for_project(project_id: str, status: str) -> list[dict[str, Any]]:
+    rows = _request_json(
+        "/rest/v1/tasks",
+        {
+            "select": "id,project_id,status,created_at,generation_started_at,params",
+            "project_id": f"eq.{project_id}",
+            "status": f"eq.{status}",
+            "order": "created_at.asc",
+        },
+    )
+    if not isinstance(rows, list):
+        raise ProbeError(f"Expected list response when loading tasks for project {project_id}")
+    return rows
+
+
+def load_non_live_test_tasks(user_id: str) -> list[dict[str, Any]]:
+    projects = load_projects_for_user(user_id)
+    by_project = {project["id"]: project for project in projects if project.get("id")}
+    unexpected: list[dict[str, Any]] = []
+    for project_id in by_project:
+        for status in ("Queued", "In Progress"):
+            rows = _load_tasks_for_project(project_id, status)
+            for row in rows:
+                params = row.get("params") or {}
+                live_test_flag = str(params.get("live_test", "false")).lower() == "true"
+                if live_test_flag:
+                    continue
+                unexpected.append(
+                    {
+                        "id": row.get("id"),
+                        "project_id": project_id,
+                        "project_name": by_project[project_id].get("name"),
+                        "status": row.get("status"),
+                        "created_at": row.get("created_at"),
+                        "generation_started_at": row.get("generation_started_at"),
+                        "live_test": params.get("live_test", False),
+                    }
+                )
+    return unexpected
+
+
+def mask_identifier(value: str) -> str:
+    if len(value) <= 12:
+        return value
+    return f"{value[:8]}...{value[-4:]}"
+
+
+def main() -> int:
+    load_environment()
+    token = get_live_test_token()
+
+    schema_probe = assert_user_api_token_shape()
+    user_id = resolve_token_to_user_id(token)
+    projects = load_projects_for_user(user_id)
+    unexpected_tasks = load_non_live_test_tasks(user_id)
+
+    output = {
+        "schema_probe": schema_probe,
+        "resolved_user_id": user_id,
+        "resolved_user_id_masked": mask_identifier(user_id),
+        "project_count": len(projects),
+        "projects": [
+            {
+                "id": project.get("id"),
+                "name": project.get("name"),
+                "created_at": project.get("created_at"),
+            }
+            for project in projects
+        ],
+        "unexpected_non_live_tasks": unexpected_tasks,
+    }
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ProbeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/live_test/task_spoofer.py
+++ b/scripts/live_test/task_spoofer.py
@@ -1,0 +1,95 @@
+"""Fixture-backed task insertion helpers for the live-test harness."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+from scripts.live_test import config
+
+
+DEFAULT_FIXTURE_BY_TASK_TYPE = {
+    "qwen_image": "qwen_image_basic",
+    "qwen_image_2512": "qwen_image_basic",
+    "qwen_image_edit": "qwen_image_edit_basic",
+    "qwen_image_style": "qwen_image_style_db_task",
+    "z_image_turbo_i2i": "z_image_turbo_i2i_basic",
+    "individual_travel_segment": "wan22_i2v_individual_segment",
+}
+
+
+def _coerce_rows(result: Any) -> list[dict[str, Any]]:
+    data = getattr(result, "data", None)
+    if not data:
+        return []
+    if isinstance(data, dict):
+        return [data]
+    return [row for row in data if isinstance(row, dict)]
+
+
+def _deep_merge(base: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
+    merged = copy.deepcopy(base)
+    for key, value in (overrides or {}).items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
+def _fixture_path(case_name: str) -> Path:
+    try:
+        return config.FIXTURES[case_name]
+    except KeyError as exc:
+        raise KeyError(f"Unknown fixture case: {case_name}") from exc
+
+
+def _default_fixture_case(task_type: str) -> str:
+    try:
+        return DEFAULT_FIXTURE_BY_TASK_TYPE[task_type]
+    except KeyError as exc:
+        raise ValueError(
+            f"No default fixture mapping exists for task_type={task_type!r}; pass fixture_case or fixture_payload"
+        ) from exc
+
+
+def load_fixture(case_name: str) -> dict[str, Any]:
+    """Load a prepared worker-matrix fixture by case name."""
+    return json.loads(_fixture_path(case_name).read_text(encoding="utf-8"))
+
+
+def insert_spoof_task(
+    db,
+    project_id: str,
+    task_type: str,
+    params_overrides: dict[str, Any] | None,
+    *,
+    fixture_case: str | None = None,
+    fixture_payload: dict[str, Any] | None = None,
+) -> str:
+    """Insert a live-test task row based on a fixture payload."""
+    source_payload = fixture_payload if fixture_payload is not None else load_fixture(
+        fixture_case or _default_fixture_case(task_type)
+    )
+    payload = copy.deepcopy(source_payload)
+    payload.pop("notes", None)
+    payload["project_id"] = project_id
+    payload["task_type"] = task_type
+    payload["status"] = "Queued"
+
+    params = payload.get("params")
+    if not isinstance(params, dict):
+        params = {}
+    payload["params"] = _deep_merge(params, params_overrides or {})
+    payload["params"]["live_test"] = True
+
+    result = db.supabase.table("tasks").insert(payload).execute()
+    rows = _coerce_rows(result)
+    if len(rows) != 1 or not rows[0].get("id"):
+        raise RuntimeError("Failed to insert spoof task row")
+    return str(rows[0]["id"])
+
+
+__all__ = ["DEFAULT_FIXTURE_BY_TASK_TYPE", "insert_spoof_task", "load_fixture"]

--- a/scripts/live_test/terminate_guard.py
+++ b/scripts/live_test/terminate_guard.py
@@ -1,0 +1,20 @@
+"""Termination safety wrapper for live RunPod tests."""
+
+from __future__ import annotations
+
+import os
+
+import scripts.live_test as live_test_pkg
+
+
+def guarded_terminate(pod_id: str | None, api_key: str | None, *, no_terminate: bool) -> bool:
+    """Terminate the pod only when neither the CLI flag nor env opt-out is set."""
+    if not pod_id or not api_key:
+        return False
+    if no_terminate or os.getenv("REIGH_LIVE_TEST_NO_TERMINATE") == "1":
+        return False
+    live_test_pkg.terminate_pod(pod_id, api_key)
+    return True
+
+
+__all__ = ["guarded_terminate"]

--- a/scripts/live_test/tests/test_primitives.py
+++ b/scripts/live_test/tests/test_primitives.py
@@ -1,0 +1,851 @@
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import types
+from collections import deque
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.live_test.completion_poller import TaskResult, poll_until_complete
+from scripts.live_test.heartbeat_waiter import WorkerReadyTimeoutError, wait_until_ready
+from scripts.live_test.launch_command import build_direct_worker_command, build_run_worker_command
+from scripts.live_test.matrix import MATRIX, MatrixCase, run_matrix
+from scripts.live_test import main as live_test_main
+from scripts.live_test.preflight import (
+    LIVE_TEST_PROJECT_NAME,
+    UnexpectedUserWorkError,
+    assert_user_queue_clean,
+    get_or_create_live_test_project,
+)
+from scripts.live_test.report import write_report
+from scripts.live_test.safety_gate import UnsafeTakeoverError, assert_safe_to_take_over
+from scripts.live_test.ssh_bootstrap import (
+    KILL_COMMAND,
+    WorkerProcessInfo,
+    capture_current_worker_cmdline,
+    kill_supervisor_and_worker,
+)
+from scripts.live_test.task_spoofer import insert_spoof_task
+from scripts.live_test.terminate_guard import guarded_terminate
+from scripts.live_test.token_resolver import TokenResolutionError, resolve_token_to_user_id
+from scripts.live_test.variant_fresh import run as run_variant_fresh
+from scripts.live_test.variant_update import _spawn_takeover_pod, run as run_variant_update
+
+
+def _iso_now(offset_seconds: int = 0) -> str:
+    return (datetime.now(timezone.utc) + timedelta(seconds=offset_seconds)).isoformat()
+
+
+def _lookup(row: dict, key: str):
+    current = row
+    for part in key.split("."):
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+class FakeResult:
+    def __init__(self, data):
+        self.data = data
+
+
+class SequenceResponder:
+    def __init__(self, responses):
+        self._responses = deque(copy.deepcopy(list(responses)))
+
+    def __call__(self, _query):
+        if len(self._responses) > 1:
+            return self._responses.popleft()
+        return copy.deepcopy(self._responses[0]) if self._responses else []
+
+
+class FakeQuery:
+    def __init__(self, supabase: "FakeSupabase", table_name: str):
+        self.supabase = supabase
+        self.table_name = table_name
+        self.filters = []
+        self.order_key = None
+        self.order_desc = False
+        self.insert_payload = None
+
+    def select(self, *_args, **_kwargs):
+        return self
+
+    def eq(self, key, value):
+        self.filters.append(lambda row: _lookup(row, key) == value)
+        return self
+
+    def in_(self, key, values):
+        allowed = set(values)
+        self.filters.append(lambda row: _lookup(row, key) in allowed)
+        return self
+
+    def gte(self, key, value):
+        self.filters.append(lambda row: (_lookup(row, key) or "") >= value)
+        return self
+
+    def order(self, key, desc=False):
+        self.order_key = key
+        self.order_desc = desc
+        return self
+
+    def insert(self, payload):
+        self.insert_payload = copy.deepcopy(payload)
+        return self
+
+    def single(self):
+        return self
+
+    def execute(self):
+        if self.insert_payload is not None:
+            row = copy.deepcopy(self.insert_payload)
+            row.setdefault("id", f"{self.table_name}-row-{len(self.supabase.tables.setdefault(self.table_name, [])) + 1}")
+            self.supabase.tables.setdefault(self.table_name, []).append(copy.deepcopy(row))
+            self.supabase.inserted.setdefault(self.table_name, []).append(copy.deepcopy(row))
+            return FakeResult([row])
+
+        source = self.supabase.sources.get(self.table_name, self.supabase.tables.get(self.table_name, []))
+        if callable(source):
+            rows = source(self)
+        else:
+            rows = copy.deepcopy(source)
+
+        filtered = []
+        for row in rows:
+            if all(predicate(row) for predicate in self.filters):
+                filtered.append(copy.deepcopy(row))
+
+        if self.order_key is not None:
+            filtered.sort(key=lambda row: _lookup(row, self.order_key) or "", reverse=self.order_desc)
+
+        return FakeResult(filtered)
+
+
+class FakeSupabase:
+    def __init__(self, *, tables=None, sources=None):
+        self.tables = copy.deepcopy(tables or {})
+        self.sources = dict(sources or {})
+        self.inserted = {}
+
+    def table(self, table_name: str) -> FakeQuery:
+        return FakeQuery(self, table_name)
+
+
+class FakeDB:
+    def __init__(self, *, tables=None, sources=None):
+        self.supabase = FakeSupabase(tables=tables, sources=sources)
+
+
+class ScriptedSSH:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.commands = []
+
+    def execute_command(self, command, timeout=600):
+        self.commands.append((command, timeout))
+        if not self.responses:
+            return 0, "", ""
+        matcher, response = self.responses.pop(0)
+        if matcher is not None:
+            assert matcher in command
+        return response
+
+
+def test_token_resolver_returns_user_id():
+    db = FakeDB(tables={"user_api_tokens": [{"user_id": "user-123", "token": "secret"}]})
+    assert resolve_token_to_user_id(db, "secret") == "user-123"
+
+
+def test_token_resolver_raises_on_missing():
+    db = FakeDB(tables={"user_api_tokens": []})
+    with pytest.raises(TokenResolutionError):
+        resolve_token_to_user_id(db, "missing")
+
+
+def test_preflight_raises_on_stray_user_work():
+    db = FakeDB(
+        tables={
+            "tasks": [
+                {
+                    "id": "task-1",
+                    "status": "Queued",
+                    "params": {"live_test": False},
+                    "projects": {"user_id": "user-1"},
+                }
+            ]
+        }
+    )
+    with pytest.raises(UnexpectedUserWorkError):
+        assert_user_queue_clean(db, "user-1")
+
+
+def test_preflight_passes_when_clean():
+    db = FakeDB(
+        tables={
+            "tasks": [
+                {
+                    "id": "task-1",
+                    "status": "Queued",
+                    "params": {"live_test": True},
+                    "projects": {"user_id": "user-1"},
+                }
+            ],
+            "projects": [{"id": "project-1", "user_id": "user-1", "name": LIVE_TEST_PROJECT_NAME}],
+        }
+    )
+    assert_user_queue_clean(db, "user-1")
+    assert get_or_create_live_test_project(db, "user-1") == "project-1"
+
+
+def test_task_spoofer_stamps_live_test_and_queued_status():
+    db = FakeDB(tables={"tasks": []})
+    task_id = insert_spoof_task(
+        db,
+        "project-1",
+        "qwen_image",
+        {"prompt": "overridden"},
+        fixture_payload={"notes": "strip me", "params": {"prompt": "base prompt"}},
+    )
+    inserted = db.supabase.inserted["tasks"][0]
+    assert task_id == inserted["id"]
+    assert inserted["status"] == "Queued"
+    assert inserted["params"]["prompt"] == "overridden"
+    assert inserted["params"]["live_test"] is True
+    assert "notes" not in inserted
+
+
+def test_completion_poller_returns_on_complete(monkeypatch: pytest.MonkeyPatch):
+    task_rows = SequenceResponder(
+        [
+            [{"id": "task-1", "project_id": "project-1", "task_type": "qwen_image", "status": "Queued", "created_at": _iso_now(-10)}],
+            [{"id": "task-1", "project_id": "project-1", "task_type": "qwen_image", "status": "Complete", "created_at": _iso_now(-10), "output_location": "https://out.example/result.png"}],
+        ]
+    )
+    generations = [
+        {
+            "id": "gen-1",
+            "project_id": "project-1",
+            "created_at": _iso_now(-5),
+            "tasks": ["task-1"],
+            "params": {},
+            "location": "https://out.example/result.png",
+        }
+    ]
+    db = FakeDB(sources={"tasks": task_rows}, tables={"generations": generations})
+    monkeypatch.setattr("scripts.live_test.completion_poller.time.sleep", lambda _interval: None)
+    result = poll_until_complete(db, "task-1", "project-1", timeout_sec=2, interval_sec=0, case_name="case", task_type="qwen_image")
+    assert result.final_status == "Complete"
+    assert result.generation_ids == ["gen-1"]
+    assert result.output_location == "https://out.example/result.png"
+    assert result.error_summary is None
+
+
+def test_completion_poller_times_out(monkeypatch: pytest.MonkeyPatch):
+    db = FakeDB(
+        tables={
+            "tasks": [
+                {"id": "task-1", "project_id": "project-1", "task_type": "qwen_image", "status": "Queued", "created_at": _iso_now(-10)}
+            ],
+            "generations": [],
+        }
+    )
+    monotonic_values = iter([0.0, 0.4, 1.2, 1.4, 1.6])
+    monkeypatch.setattr("scripts.live_test.completion_poller.time.monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr("scripts.live_test.completion_poller.time.sleep", lambda _interval: None)
+    result = poll_until_complete(db, "task-1", "project-1", timeout_sec=1, interval_sec=0, case_name="case", task_type="qwen_image")
+    assert result.final_status == "Queued"
+    assert "Timed out waiting for task task-1" in (result.error_summary or "")
+
+
+def test_completion_poller_records_failure(monkeypatch: pytest.MonkeyPatch):
+    db = FakeDB(
+        tables={
+            "tasks": [
+                {
+                    "id": "task-1",
+                    "project_id": "project-1",
+                    "task_type": "qwen_image",
+                    "status": "Failed",
+                    "error_message": "backend exploded",
+                    "created_at": _iso_now(-10),
+                }
+            ],
+            "generations": [],
+        }
+    )
+    monkeypatch.setattr("scripts.live_test.completion_poller.time.sleep", lambda _interval: None)
+    result = poll_until_complete(db, "task-1", "project-1", timeout_sec=1, interval_sec=0)
+    assert result.final_status == "Failed"
+    assert result.error_summary == "backend exploded"
+
+
+def test_heartbeat_waiter_requires_dwell_not_startup_phase(monkeypatch: pytest.MonkeyPatch):
+    workers = SequenceResponder(
+        [
+            [{"id": "worker-1", "last_heartbeat": _iso_now(), "startup_phase": None}],
+            [{"id": "worker-1", "last_heartbeat": _iso_now(), "startup_phase": None}],
+        ]
+    )
+    db = FakeDB(sources={"workers": workers})
+    monkeypatch.setattr("scripts.live_test.heartbeat_waiter.time.sleep", lambda _interval: None)
+    worker = wait_until_ready(db, "worker-1", timeout_sec=1, interval_sec=0, dwell_polls=2)
+    assert worker["id"] == "worker-1"
+
+
+def test_safety_gate_rejects_fresh_in_progress_for_user():
+    db = FakeDB(
+        tables={
+            "tasks": [
+                {
+                    "id": "task-1",
+                    "status": "In Progress",
+                    "generation_started_at": _iso_now(-10),
+                    "projects": {"user_id": "user-1"},
+                }
+            ]
+        }
+    )
+    with pytest.raises(UnsafeTakeoverError):
+        assert_safe_to_take_over(db, "pod-1", "user-1")
+
+
+def test_safety_gate_rejects_fresh_heartbeat_when_not_allowed():
+    db = FakeDB(
+        tables={
+            "tasks": [],
+            "workers": [{"id": "pod-1", "last_heartbeat": _iso_now()}],
+        }
+    )
+    with pytest.raises(UnsafeTakeoverError):
+        assert_safe_to_take_over(db, "pod-1", "user-1", allow_fresh_heartbeat=False)
+
+
+def test_safety_gate_permits_fresh_heartbeat_when_allowed_but_still_rejects_live_pat_work():
+    clean_db = FakeDB(
+        tables={
+            "tasks": [],
+            "workers": [{"id": "pod-1", "last_heartbeat": _iso_now()}],
+        }
+    )
+    assert_safe_to_take_over(clean_db, "pod-1", "user-1", allow_fresh_heartbeat=True)
+
+    busy_db = FakeDB(
+        tables={
+            "tasks": [
+                {
+                    "id": "task-2",
+                    "status": "In Progress",
+                    "generation_started_at": _iso_now(-15),
+                    "projects": {"user_id": "user-1"},
+                }
+            ],
+            "workers": [{"id": "pod-1", "last_heartbeat": _iso_now()}],
+        }
+    )
+    with pytest.raises(UnsafeTakeoverError):
+        assert_safe_to_take_over(busy_db, "pod-1", "user-1", allow_fresh_heartbeat=True)
+
+
+def test_terminate_guard_respects_env_var(monkeypatch: pytest.MonkeyPatch):
+    calls = []
+    monkeypatch.setenv("REIGH_LIVE_TEST_NO_TERMINATE", "1")
+    monkeypatch.setattr("scripts.live_test.terminate_guard.live_test_pkg.terminate_pod", lambda pod_id, api_key: calls.append((pod_id, api_key)))
+    assert guarded_terminate("pod-1", "api-key", no_terminate=False) is False
+    assert calls == []
+
+
+def test_terminate_guard_respects_cli_flag(monkeypatch: pytest.MonkeyPatch):
+    calls = []
+    monkeypatch.delenv("REIGH_LIVE_TEST_NO_TERMINATE", raising=False)
+    monkeypatch.setattr("scripts.live_test.terminate_guard.live_test_pkg.terminate_pod", lambda pod_id, api_key: calls.append((pod_id, api_key)))
+    assert guarded_terminate("pod-1", "api-key", no_terminate=True) is False
+    assert calls == []
+
+
+def test_terminate_guard_skips_on_exception_path(monkeypatch: pytest.MonkeyPatch):
+    calls = []
+    monkeypatch.delenv("REIGH_LIVE_TEST_NO_TERMINATE", raising=False)
+    monkeypatch.setattr("scripts.live_test.terminate_guard.live_test_pkg.terminate_pod", lambda pod_id, api_key: calls.append((pod_id, api_key)))
+    with pytest.raises(RuntimeError):
+        try:
+            raise RuntimeError("boom")
+        finally:
+            assert guarded_terminate(None, "api-key", no_terminate=False) is False
+    assert calls == []
+
+
+def test_build_run_worker_command_uses_run_worker_py_and_idle_zero():
+    command = build_run_worker_command(
+        "/workspace/Reigh-Worker-LiveTest",
+        reigh_token="token-1",
+        supabase_url="https://supabase.example",
+        worker_id="worker-1",
+        wgp_profile=3,
+        idle_release_minutes=0,
+    )
+    assert "python run_worker.py" in command
+    assert "--idle-release-minutes 0" in command
+    assert "--save-logging logs/worker.log" in command
+
+
+def test_build_direct_worker_command_roundtrips_template_cmdline():
+    command = build_direct_worker_command(
+        "/workspace/Reigh-Worker",
+        cli_args=["python", "worker.py", "--task-id", "task-1", "--gpu-id", "0"],
+    )
+    assert command.startswith("cd /workspace/Reigh-Worker && nohup python worker.py")
+    assert "> logs/startup.log 2>&1 &" in command
+
+
+def test_capture_cmdline_detects_supervisor_family_from_run_worker_ps():
+    ssh = ScriptedSSH(
+        [
+            (
+                "ps -eo pid=,args=",
+                (
+                    0,
+                    "123 python run_worker.py --worker worker-1\n124 python worker.py --task-id task-1\n",
+                    "",
+                ),
+            )
+        ]
+    )
+    info = capture_current_worker_cmdline(ssh)
+    assert info == WorkerProcessInfo(
+        family="supervisor",
+        cmdline=["python", "run_worker.py", "--worker", "worker-1"],
+        pid=123,
+    )
+
+
+def test_capture_cmdline_detects_direct_family_from_template_ps():
+    ssh = ScriptedSSH(
+        [
+            (
+                "ps -eo pid=,args=",
+                (0, "222 python worker.py --task-id task-1 --gpu-id 0\n", ""),
+            )
+        ]
+    )
+    info = capture_current_worker_cmdline(ssh)
+    assert info == WorkerProcessInfo(
+        family="direct",
+        cmdline=["python", "worker.py", "--task-id", "task-1", "--gpu-id", "0"],
+        pid=222,
+    )
+
+
+def test_kill_supervisor_and_worker_patterns_cover_both_families(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("scripts.live_test.ssh_bootstrap.time.sleep", lambda _interval: None)
+    ssh = ScriptedSSH(
+        [
+            (None, (0, "", "")),
+            ("pgrep -af run_worker.py", (0, "123 python run_worker.py\n", "")),
+            ("pgrep -af run_worker.py", (0, "", "")),
+        ]
+    )
+    kill_supervisor_and_worker(ssh)
+    assert ssh.commands[0][0] == KILL_COMMAND
+    assert "pgrep -af run_worker.py" in ssh.commands[1][0]
+    assert "pgrep -af 'python worker.py'" in ssh.commands[1][0]
+    assert "pgrep -af source.runtime.worker" in ssh.commands[1][0]
+
+
+def test_matrix_contains_exactly_eight_cases():
+    assert len(MATRIX) == 8
+    assert [case.name for case in MATRIX].count("z_image_turbo_i2i") == 1
+    assert any(case.task_type == "z_image_turbo_i2i" for case in MATRIX)
+
+
+def test_run_matrix_continues_after_individual_case_failures(monkeypatch: pytest.MonkeyPatch):
+    cases = [
+        MatrixCase(name="case-a", task_type="qwen_image", fixture_key="qwen_image_basic", timeout_sec=5),
+        MatrixCase(name="case-b", task_type="qwen_image_style", fixture_key="qwen_image_style_db_task", timeout_sec=5),
+    ]
+
+    inserted = []
+    polled = []
+
+    def fake_insert(_db, _project_id, task_type, _params_overrides, **_kwargs):
+        task_id = f"{task_type}-task-{len(inserted) + 1}"
+        inserted.append(task_id)
+        return task_id
+
+    def fake_poll(_db, task_id, _project_id, **kwargs):
+        polled.append(task_id)
+        if task_id.startswith("qwen_image-task"):
+            return TaskResult(
+                task_id=task_id,
+                case_name=kwargs["case_name"],
+                task_type=kwargs["task_type"],
+                final_status="Failed",
+                output_location=None,
+                generation_ids=[],
+                elapsed_sec=1.0,
+                error_summary="backend exploded",
+            )
+        return TaskResult(
+            task_id=task_id,
+            case_name=kwargs["case_name"],
+            task_type=kwargs["task_type"],
+            final_status="Complete",
+            output_location="https://out.example/image.png",
+            generation_ids=["gen-2"],
+            elapsed_sec=1.0,
+            error_summary=None,
+        )
+
+    monkeypatch.setattr("scripts.live_test.matrix.insert_spoof_task", fake_insert)
+    monkeypatch.setattr("scripts.live_test.matrix.poll_until_complete", fake_poll)
+
+    results = run_matrix(object(), "project-1", cases)
+    assert [result.case_name for result in results] == ["case-a", "case-b"]
+    assert results[0].final_status == "Failed"
+    assert results[1].final_status == "Complete"
+    assert inserted == ["qwen_image-task-1", "qwen_image_style-task-2"]
+    assert polled == inserted
+
+
+def test_write_report_outputs_json_and_markdown(tmp_path: Path):
+    results = [
+        TaskResult(
+            task_id="task-1",
+            case_name="case-a",
+            task_type="qwen_image",
+            final_status="Complete",
+            output_location="https://out.example/a.png",
+            generation_ids=["gen-1"],
+            elapsed_sec=1.234,
+            error_summary=None,
+        ),
+        TaskResult(
+            task_id="task-2",
+            case_name="case-b",
+            task_type="qwen_image_style",
+            final_status="Failed",
+            output_location=None,
+            generation_ids=[],
+            elapsed_sec=2.345,
+            error_summary="backend exploded",
+        ),
+    ]
+    out_dir = write_report(results, "fresh", "pod-1", tmp_path / "runs" / "case-1")
+    report_json = json.loads((out_dir / "report.json").read_text(encoding="utf-8"))
+    report_md = (out_dir / "report.md").read_text(encoding="utf-8")
+    assert report_json["passed"] == 1
+    assert report_json["total"] == 2
+    assert "Summary: `1/2 passed`" in report_md
+
+
+def test_variant_fresh_dry_run_uses_livetest_workspace_and_env_exports(capsys, monkeypatch: pytest.MonkeyPatch):
+    cases = [MatrixCase(name="case-a", task_type="qwen_image", fixture_key="qwen_image_basic", timeout_sec=900)]
+    monkeypatch.setattr(
+        "scripts.live_test.variant_fresh._prepare_context",
+        lambda _args: {
+            "db": object(),
+            "token": "token-1",
+            "user_id": "user-1",
+            "project_id": "project-1",
+            "cases": cases,
+        },
+    )
+    monkeypatch.setattr("scripts.live_test.variant_fresh._validate_cases", lambda _cases, _project_id: None)
+    monkeypatch.setattr(
+        "scripts.live_test.variant_fresh.config.require_env",
+        lambda name: {
+            "SUPABASE_URL": "https://supabase.example",
+        }[name],
+    )
+    args = SimpleNamespace(
+        dry_run=True,
+        no_terminate=False,
+        wgp_profile=3,
+        timeout_image=900,
+        timeout_travel_segment=1500,
+        timeout_travel_orchestrator=2400,
+        anchor_image_a="https://example.com/a.png",
+        anchor_image_b="https://example.com/b.png",
+        ref="main",
+    )
+    assert run_variant_fresh(args) == 0
+    output = capsys.readouterr().out
+    assert "/workspace/Reigh-Worker-LiveTest" in output
+    assert "Terminate after run: True" in output
+    assert "REIGH_ACCESS_TOKEN" in output
+    assert "SUPABASE_SERVICE_ROLE_KEY" in output
+    assert "SUPABASE_URL" in output
+    assert "WORKER_DB_CLIENT_AUTH_MODE" in output
+
+
+def test_spawn_takeover_pod_calls_create_record_before_spawn_and_start(monkeypatch: pytest.MonkeyPatch):
+    events = []
+
+    class FakeDB:
+        async def create_worker_record(self, worker_id, instance_type):
+            events.append(("create_worker_record", worker_id, instance_type))
+            return True
+
+        async def update_worker_status(self, worker_id, status, metadata):
+            events.append(("update_worker_status", worker_id, status, metadata["runpod_id"]))
+            return True
+
+    class FakeSpawner:
+        def __init__(self):
+            events.append(("init",))
+            self.gpu_type = "NVIDIA GeForce RTX 4090"
+
+        def generate_worker_id(self):
+            events.append(("generate_worker_id",))
+            return "worker-123"
+
+        async def spawn_worker(self, worker_id):
+            events.append(("spawn_worker", worker_id))
+            return {"runpod_id": "pod-456", "pod_details": {"id": "pod-456"}}
+
+        async def start_worker_process(self, pod_id, worker_id, has_pending_tasks=False):
+            events.append(("start_worker_process", pod_id, worker_id, has_pending_tasks))
+            return True
+
+    def _fake_factory(config, db):
+        return FakeSpawner()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "gpu_orchestrator.worker_spawner",
+        types.SimpleNamespace(create_worker_spawner=_fake_factory),
+    )
+
+    worker_id, pod_id = _spawn_takeover_pod(FakeDB(), "api-key")
+    assert (worker_id, pod_id) == ("worker-123", "pod-456")
+    assert events == [
+        ("init",),
+        ("generate_worker_id",),
+        ("create_worker_record", "worker-123", "NVIDIA GeForce RTX 4090"),
+        ("spawn_worker", "worker-123"),
+        ("update_worker_status", "worker-123", "spawning", "pod-456"),
+        ("start_worker_process", "pod-456", "worker-123", False),
+    ]
+
+
+def test_variant_update_spawn_takeover_threads_worker_id_not_pod_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    safety_calls = []
+    wait_calls = []
+    launched = []
+    cleanup_calls = []
+    restore_calls = []
+
+    cases = [MatrixCase(name="case-a", task_type="qwen_image", fixture_key="qwen_image_basic", timeout_sec=900)]
+    monkeypatch.setattr(
+        "scripts.live_test.variant_update._prepare_context",
+        lambda _args: {
+            "db": object(),
+            "token": "token-1",
+            "user_id": "user-1",
+            "project_id": "project-1",
+            "cases": cases,
+        },
+    )
+    monkeypatch.setattr("scripts.live_test.variant_update._validate_cases", lambda _cases, _project_id: None)
+    monkeypatch.setattr(
+        "scripts.live_test.variant_update.config.require_env",
+        lambda name: {
+            "RUNPOD_API_KEY": "api-key",
+            "SUPABASE_URL": "https://supabase.example",
+            "SUPABASE_SERVICE_ROLE_KEY": "service-key",
+        }[name],
+    )
+    monkeypatch.setattr("scripts.live_test.variant_update._runs_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        "scripts.live_test.variant_update._spawn_takeover_pod",
+        lambda _db, _api_key: ("worker-123", "pod-456"),
+    )
+    monkeypatch.setattr(
+        "scripts.live_test.variant_update.assert_safe_to_take_over",
+        lambda _db, pod_id, user_id, allow_fresh_heartbeat=False: safety_calls.append(
+            (pod_id, user_id, allow_fresh_heartbeat)
+        ),
+    )
+    monkeypatch.setattr("scripts.live_test.variant_update.snapshot_local_state", lambda _path: "snapshot")
+    monkeypatch.setattr(
+        "scripts.live_test.variant_update.push_working_copy_to_temp_branch",
+        lambda _path, _snapshot: ("live-test/branch", "sha-1"),
+    )
+
+    class DummySSH:
+        def execute_command(self, _command, timeout=600):
+            return 0, "", ""
+
+        def disconnect(self):
+            return None
+
+    monkeypatch.setattr("scripts.live_test.variant_update.open_session", lambda _pod_id, _api_key: DummySSH())
+    monkeypatch.setattr("scripts.live_test.variant_update._read_remote_branch", lambda _ssh: "main")
+    monkeypatch.setattr("scripts.live_test.variant_update._read_remote_sha", lambda _ssh: "sha-prev")
+    monkeypatch.setattr(
+        "scripts.live_test.variant_update.capture_current_worker_cmdline",
+        lambda _ssh: WorkerProcessInfo(
+            family="supervisor",
+            cmdline=["python", "run_worker.py", "--worker", "old-worker"],
+            pid=123,
+        ),
+    )
+    monkeypatch.setattr("scripts.live_test.variant_update._remote_checkout_and_sync", lambda _ssh, _branch: None)
+    monkeypatch.setattr("scripts.live_test.variant_update.kill_supervisor_and_worker", lambda _ssh: None)
+    monkeypatch.setattr(
+        "scripts.live_test.variant_update.launch_worker_detached",
+        lambda _ssh, command: launched.append(command),
+    )
+    monkeypatch.setattr(
+        "scripts.live_test.variant_update.wait_until_ready",
+        lambda _db, worker_id, timeout_sec=900: wait_calls.append((worker_id, timeout_sec)),
+    )
+    monkeypatch.setattr("scripts.live_test.variant_update.run_matrix", lambda _db, _project_id, _cases: [])
+    monkeypatch.setattr(
+        "scripts.live_test.variant_update.write_report",
+        lambda _results, _variant, _pod_id, _out_dir: tmp_path,
+    )
+    monkeypatch.setattr(
+        "scripts.live_test.variant_update._restore_remote_state",
+        lambda _ssh, **kwargs: restore_calls.append(kwargs),
+    )
+    monkeypatch.setattr(
+        "scripts.live_test.variant_update.cleanup_temp_branch",
+        lambda branch, preserve, submodule_path="reigh-worker": cleanup_calls.append((branch, preserve, submodule_path))
+        or branch,
+    )
+    monkeypatch.setattr(
+        "scripts.live_test.variant_update.restore_local_state",
+        lambda _path, _snapshot: restore_calls.append({"local_restore": True}),
+    )
+    monkeypatch.setattr("scripts.live_test.variant_update.fetch_worker_logs", lambda _ssh, _workdir: "logs")
+    monkeypatch.setattr("scripts.live_test.variant_update.guarded_terminate", lambda *_args, **_kwargs: False)
+
+    args = SimpleNamespace(
+        dry_run=False,
+        spawn_takeover=True,
+        pod_id=None,
+        no_terminate=True,
+        wgp_profile=3,
+        timeout_image=900,
+        timeout_travel_segment=1500,
+        timeout_travel_orchestrator=2400,
+        anchor_image_a="https://example.com/a.png",
+        anchor_image_b="https://example.com/b.png",
+        ref="main",
+    )
+    assert run_variant_update(args) == 0
+    assert safety_calls == [("pod-456", "user-1", True)]
+    assert wait_calls == [("worker-123", 900)]
+    assert any("--worker worker-123" in command for command in launched)
+    assert all("--worker pod-456" not in command for command in launched)
+    assert cleanup_calls == [("live-test/branch", False, "reigh-worker")]
+
+
+def test_variant_update_existing_mode_uses_stale_heartbeat_gate(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    safety_calls = []
+    wait_calls = []
+
+    cases = [MatrixCase(name="case-a", task_type="qwen_image", fixture_key="qwen_image_basic", timeout_sec=900)]
+    monkeypatch.setattr(
+        "scripts.live_test.variant_update._prepare_context",
+        lambda _args: {
+            "db": object(),
+            "token": "token-1",
+            "user_id": "user-1",
+            "project_id": "project-1",
+            "cases": cases,
+        },
+    )
+    monkeypatch.setattr("scripts.live_test.variant_update._validate_cases", lambda _cases, _project_id: None)
+    monkeypatch.setattr(
+        "scripts.live_test.variant_update.config.require_env",
+        lambda name: {
+            "RUNPOD_API_KEY": "api-key",
+            "SUPABASE_URL": "https://supabase.example",
+            "SUPABASE_SERVICE_ROLE_KEY": "service-key",
+        }[name],
+    )
+    monkeypatch.setattr("scripts.live_test.variant_update._runs_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        "scripts.live_test.variant_update.assert_safe_to_take_over",
+        lambda _db, pod_id, user_id, allow_fresh_heartbeat=False: safety_calls.append(
+            (pod_id, user_id, allow_fresh_heartbeat)
+        ),
+    )
+    monkeypatch.setattr("scripts.live_test.variant_update.snapshot_local_state", lambda _path: "snapshot")
+    monkeypatch.setattr(
+        "scripts.live_test.variant_update.push_working_copy_to_temp_branch",
+        lambda _path, _snapshot: ("live-test/branch", "sha-1"),
+    )
+
+    class DummySSH:
+        def execute_command(self, _command, timeout=600):
+            return 0, "", ""
+
+        def disconnect(self):
+            return None
+
+    monkeypatch.setattr("scripts.live_test.variant_update.open_session", lambda _pod_id, _api_key: DummySSH())
+    monkeypatch.setattr("scripts.live_test.variant_update._read_remote_branch", lambda _ssh: "main")
+    monkeypatch.setattr("scripts.live_test.variant_update._read_remote_sha", lambda _ssh: "sha-prev")
+    monkeypatch.setattr(
+        "scripts.live_test.variant_update.capture_current_worker_cmdline",
+        lambda _ssh: WorkerProcessInfo(
+            family="supervisor",
+            cmdline=["python", "run_worker.py", "--worker", "worker-prev"],
+            pid=123,
+        ),
+    )
+    monkeypatch.setattr("scripts.live_test.variant_update._resolve_existing_worker_id", lambda _db, _pod_id, _prev_proc: "worker-prev")
+    monkeypatch.setattr("scripts.live_test.variant_update._remote_checkout_and_sync", lambda _ssh, _branch: None)
+    monkeypatch.setattr("scripts.live_test.variant_update.kill_supervisor_and_worker", lambda _ssh: None)
+    monkeypatch.setattr("scripts.live_test.variant_update.launch_worker_detached", lambda _ssh, _command: None)
+    monkeypatch.setattr(
+        "scripts.live_test.variant_update.wait_until_ready",
+        lambda _db, worker_id, timeout_sec=900: wait_calls.append((worker_id, timeout_sec)),
+    )
+    monkeypatch.setattr("scripts.live_test.variant_update.run_matrix", lambda _db, _project_id, _cases: [])
+    monkeypatch.setattr("scripts.live_test.variant_update.write_report", lambda *_args, **_kwargs: tmp_path)
+    monkeypatch.setattr("scripts.live_test.variant_update._restore_remote_state", lambda _ssh, **_kwargs: None)
+    monkeypatch.setattr("scripts.live_test.variant_update.cleanup_temp_branch", lambda branch, preserve, submodule_path='reigh-worker': branch)
+    monkeypatch.setattr("scripts.live_test.variant_update.restore_local_state", lambda _path, _snapshot: None)
+    monkeypatch.setattr("scripts.live_test.variant_update.fetch_worker_logs", lambda _ssh, _workdir: "logs")
+    monkeypatch.setattr("scripts.live_test.variant_update.guarded_terminate", lambda *_args, **_kwargs: False)
+
+    args = SimpleNamespace(
+        dry_run=False,
+        spawn_takeover=False,
+        pod_id="pod-existing",
+        no_terminate=True,
+        wgp_profile=3,
+        timeout_image=900,
+        timeout_travel_segment=1500,
+        timeout_travel_orchestrator=2400,
+        anchor_image_a="https://example.com/a.png",
+        anchor_image_b="https://example.com/b.png",
+        ref="main",
+    )
+    assert run_variant_update(args) == 0
+    assert safety_calls == [("pod-existing", "user-1", False)]
+    assert wait_calls == [("worker-prev", 900)]
+
+
+def test_main_defaults_terminate_for_fresh_and_no_terminate_for_update(monkeypatch: pytest.MonkeyPatch):
+    seen = []
+
+    monkeypatch.setattr("scripts.live_test.main.run_variant_fresh", lambda args: seen.append(("fresh", args.no_terminate)) or 0)
+    monkeypatch.setattr("scripts.live_test.main.run_variant_update", lambda args: seen.append(("update", args.no_terminate)) or 0)
+
+    assert live_test_main.main(["--variant", "fresh", "--dry-run"]) == 0
+    assert live_test_main.main(["--variant", "update", "--pod-id", "pod-1", "--dry-run"]) == 0
+    assert seen == [("fresh", False), ("update", True)]

--- a/scripts/live_test/token_resolver.py
+++ b/scripts/live_test/token_resolver.py
@@ -1,0 +1,34 @@
+"""Token resolution helpers for the live-test harness."""
+
+from __future__ import annotations
+
+
+class TokenResolutionError(RuntimeError):
+    """Raised when a PAT cannot be resolved to exactly one user."""
+
+
+def resolve_token_to_user_id(db, token: str) -> str:
+    """Resolve a PAT to the owning user ID and require a single match."""
+    token_value = str(token).strip()
+    if not token_value:
+        raise TokenResolutionError("Token is empty")
+
+    result = (
+        db.supabase.table("user_api_tokens")
+        .select("user_id")
+        .eq("token", token_value)
+        .execute()
+    )
+    rows = list(result.data or [])
+    if len(rows) != 1:
+        raise TokenResolutionError(
+            f"Expected exactly one user_api_tokens row for the provided token, found {len(rows)}"
+        )
+
+    user_id = rows[0].get("user_id")
+    if not user_id:
+        raise TokenResolutionError("Matched token row did not include user_id")
+    return str(user_id)
+
+
+__all__ = ["TokenResolutionError", "resolve_token_to_user_id"]

--- a/scripts/live_test/variant_fresh.py
+++ b/scripts/live_test/variant_fresh.py
@@ -1,0 +1,208 @@
+"""Variant A driver: launch a fresh pod and run the live-test matrix."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from scripts.live_test import config
+from scripts.live_test.heartbeat_waiter import wait_until_ready
+from scripts.live_test.launch_command import build_run_worker_command
+from scripts.live_test.logger import get_logger
+from scripts.live_test.matrix import build_matrix, render_case_payload, run_matrix
+from scripts.live_test.preflight import assert_user_queue_clean, get_or_create_live_test_project
+from scripts.live_test.report import write_report
+from scripts.live_test.ssh_bootstrap import (
+    clone_repo_into,
+    export_env,
+    fetch_worker_logs,
+    launch_worker_detached,
+    open_session,
+    run_install,
+)
+from scripts.live_test.terminate_guard import guarded_terminate
+from scripts.live_test.token_resolver import resolve_token_to_user_id
+
+
+FRESH_VARIANT = "fresh"
+FRESH_WORKDIR = "/workspace/Reigh-Worker-LiveTest"
+FRESH_REPO_URL = "https://github.com/banodoco/Reigh-Worker.git"
+
+log = get_logger(__name__)
+
+
+def _timestamp_label() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _build_matrix_cases(args) -> list:
+    return build_matrix(
+        anchor_image_a=args.anchor_image_a,
+        anchor_image_b=args.anchor_image_b,
+        timeout_image_sec=args.timeout_image,
+        timeout_travel_segment_sec=args.timeout_travel_segment,
+        timeout_travel_orchestrator_sec=args.timeout_travel_orchestrator,
+    )
+
+
+def _build_worker_env(token: str, supabase_url: str, service_role_key: str) -> dict[str, str]:
+    return {
+        "REIGH_ACCESS_TOKEN": token,
+        "SUPABASE_SERVICE_ROLE_KEY": service_role_key,
+        "SUPABASE_URL": supabase_url,
+        "WORKER_DB_CLIENT_AUTH_MODE": "worker",
+    }
+
+
+def _runs_root() -> Path:
+    return config.WORKER_ROOT / "scripts" / "live_test" / "runs"
+
+
+def _prepare_context(args) -> dict[str, Any]:
+    token = config.require_env("REIGH_LIVE_TEST_TOKEN")
+    db = config.DatabaseClient()
+    user_id = resolve_token_to_user_id(db, token)
+    assert_user_queue_clean(db, user_id)
+    project_id = get_or_create_live_test_project(db, user_id)
+    cases = _build_matrix_cases(args)
+    return {
+        "db": db,
+        "token": token,
+        "user_id": user_id,
+        "project_id": project_id,
+        "cases": cases,
+    }
+
+
+def _validate_cases(cases: list, project_id: str) -> None:
+    for index, case in enumerate(cases, start=1):
+        render_case_payload(case, project_id=project_id, unique_suffix=f"fresh-{index}")
+
+
+def _print_dry_run_plan(*, token: str, project_id: str, cases: list, args) -> None:
+    supabase_url = config.require_env("SUPABASE_URL")
+    launch_command = build_run_worker_command(
+        FRESH_WORKDIR,
+        reigh_token=token,
+        supabase_url=supabase_url,
+        worker_id="<runpod-pod-id>",
+        wgp_profile=args.wgp_profile,
+        idle_release_minutes=0,
+    )
+
+    print("Variant: fresh")
+    print(f"Project ID: {project_id}")
+    print(f"Clone target: {FRESH_WORKDIR}")
+    print(f"Terminate after run: {not args.no_terminate}")
+    print("Injected env vars:")
+    for key in ("REIGH_ACCESS_TOKEN", "SUPABASE_SERVICE_ROLE_KEY", "SUPABASE_URL", "WORKER_DB_CLIENT_AUTH_MODE"):
+        print(f"- {key}")
+    print("Planned launch command:")
+    print(launch_command)
+    print("Planned tasks:")
+    for case in cases:
+        print(f"- {case.name} ({case.task_type}, timeout={case.timeout_sec}s)")
+
+
+def run(args) -> int:
+    context = _prepare_context(args)
+    token = context["token"]
+    db = context["db"]
+    project_id = context["project_id"]
+    cases = context["cases"]
+
+    _validate_cases(cases, project_id)
+
+    if args.dry_run:
+        _print_dry_run_plan(token=token, project_id=project_id, cases=cases, args=args)
+        return 0
+
+    api_key: str | None = None
+    api_key = config.require_env("RUNPOD_API_KEY")
+    supabase_url = config.require_env("SUPABASE_URL")
+    service_role_key = config.require_env("SUPABASE_SERVICE_ROLE_KEY")
+    worker_env = _build_worker_env(token, supabase_url, service_role_key)
+    out_dir = _runs_root() / _timestamp_label()
+
+    pod_id: str | None = None
+    ssh = None
+    try:
+        from runpod_lifecycle.api import create_pod as create_pod_and_wait
+        from runpod_lifecycle.api import get_network_volumes
+
+        network_volume_id: str | None = None
+        selected_volume_name: str | None = None
+        try:
+            available = get_network_volumes(api_key)
+            by_name = {v.get("name"): v.get("id") for v in available if v.get("name")}
+            for candidate in config.RUNPOD_STORAGE_VOLUMES:
+                if by_name.get(candidate):
+                    network_volume_id = by_name[candidate]
+                    selected_volume_name = candidate
+                    break
+        except Exception as exc:
+            log.warning("could not list network volumes (%s); continuing without one", exc)
+
+        if network_volume_id:
+            log.info("attaching network volume %s (%s) at %s", selected_volume_name, network_volume_id, config.RUNPOD_VOLUME_MOUNT_PATH)
+        else:
+            log.warning("no network volume matched %s; pod will only have ephemeral container disk", list(config.RUNPOD_STORAGE_VOLUMES))
+
+        pod = create_pod_and_wait(
+            api_key=api_key,
+            gpu_type_id=config.RUNPOD_GPU_TYPE,
+            image_name=config.RUNPOD_WORKER_IMAGE,
+            name=f"reigh-live-test-fresh-{_timestamp_label().lower()}",
+            network_volume_id=network_volume_id,
+            volume_mount_path=config.RUNPOD_VOLUME_MOUNT_PATH,
+            disk_in_gb=config.LIVE_TEST_DISK_SIZE_GB,
+            container_disk_in_gb=config.LIVE_TEST_CONTAINER_DISK_GB,
+            min_vcpu_count=config.RUNPOD_MIN_VCPU_COUNT,
+            min_memory_in_gb=config.RUNPOD_MIN_MEMORY_GB,
+            template_id=config.RUNPOD_TEMPLATE_ID,
+            env_vars=worker_env,
+        )
+        if not pod or not pod.get("id"):
+            raise RuntimeError("create_pod_and_wait did not return a pod id")
+
+        pod_id = str(pod["id"])
+        ssh = open_session(pod_id, api_key)
+        clone_repo_into(ssh, FRESH_WORKDIR, FRESH_REPO_URL, branch=args.ref or "main")
+        run_install(ssh, FRESH_WORKDIR)
+
+        command = build_run_worker_command(
+            FRESH_WORKDIR,
+            reigh_token=token,
+            supabase_url=supabase_url,
+            worker_id=pod_id,
+            wgp_profile=args.wgp_profile,
+            idle_release_minutes=0,
+        )
+        launch_worker_detached(ssh, export_env(worker_env) + " && " + command)
+        wait_until_ready(db, worker_id=pod_id, timeout_sec=900)
+
+        results = run_matrix(db, project_id, cases)
+        write_report(results, FRESH_VARIANT, pod_id, out_dir)
+        return 0
+    finally:
+        if ssh is not None:
+            try:
+                logs = fetch_worker_logs(ssh, FRESH_WORKDIR)
+                out_dir.mkdir(parents=True, exist_ok=True)
+                (out_dir / "worker_logs.txt").write_text(logs, encoding="utf-8")
+            except Exception as exc:
+                log.warning("failed to fetch fresh variant worker logs: %s", exc)
+            finally:
+                disconnect = getattr(ssh, "disconnect", None)
+                if callable(disconnect):
+                    disconnect()
+        guarded_terminate(pod_id, api_key if not args.dry_run else None, no_terminate=args.no_terminate)
+
+
+__all__ = [
+    "FRESH_REPO_URL",
+    "FRESH_VARIANT",
+    "FRESH_WORKDIR",
+    "run",
+]

--- a/scripts/live_test/variant_update.py
+++ b/scripts/live_test/variant_update.py
@@ -1,0 +1,378 @@
+"""Variant B driver: update/take over an installed pod and run the live-test matrix."""
+
+from __future__ import annotations
+
+import asyncio
+import shlex
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from scripts.live_test import config
+from scripts.live_test.git_ops import (
+    cleanup_temp_branch,
+    push_working_copy_to_temp_branch,
+    restore_local_state,
+    snapshot_local_state,
+)
+from scripts.live_test.heartbeat_waiter import wait_until_ready
+from scripts.live_test.launch_command import build_direct_worker_command, build_run_worker_command
+from scripts.live_test.logger import get_logger
+from scripts.live_test.matrix import build_matrix, render_case_payload, run_matrix
+from scripts.live_test.preflight import assert_user_queue_clean, get_or_create_live_test_project
+from scripts.live_test.report import write_report
+from scripts.live_test.safety_gate import assert_safe_to_take_over
+from scripts.live_test.ssh_bootstrap import (
+    WorkerProcessInfo,
+    capture_current_worker_cmdline,
+    export_env,
+    fetch_worker_logs,
+    kill_supervisor_and_worker,
+    launch_worker_detached,
+    open_session,
+)
+from scripts.live_test.terminate_guard import guarded_terminate
+from scripts.live_test.token_resolver import resolve_token_to_user_id
+
+
+UPDATE_VARIANT = "update"
+UPDATE_WORKDIR = "/workspace/Reigh-Worker"
+
+log = get_logger(__name__)
+
+
+def _timestamp_label() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _runs_root() -> Path:
+    return config.WORKER_ROOT / "scripts" / "live_test" / "runs"
+
+
+def _build_matrix_cases(args) -> list:
+    return build_matrix(
+        anchor_image_a=args.anchor_image_a,
+        anchor_image_b=args.anchor_image_b,
+        timeout_image_sec=args.timeout_image,
+        timeout_travel_segment_sec=args.timeout_travel_segment,
+        timeout_travel_orchestrator_sec=args.timeout_travel_orchestrator,
+    )
+
+
+def _build_worker_env(token: str, supabase_url: str, service_role_key: str) -> dict[str, str]:
+    return {
+        "REIGH_ACCESS_TOKEN": token,
+        "SUPABASE_SERVICE_ROLE_KEY": service_role_key,
+        "SUPABASE_URL": supabase_url,
+        "WORKER_DB_CLIENT_AUTH_MODE": "worker",
+    }
+
+
+def _prepare_context(args) -> dict[str, Any]:
+    token = config.require_env("REIGH_LIVE_TEST_TOKEN")
+    db = config.DatabaseClient()
+    user_id = resolve_token_to_user_id(db, token)
+    assert_user_queue_clean(db, user_id)
+    project_id = get_or_create_live_test_project(db, user_id)
+    cases = _build_matrix_cases(args)
+    return {
+        "db": db,
+        "token": token,
+        "user_id": user_id,
+        "project_id": project_id,
+        "cases": cases,
+    }
+
+
+def _validate_cases(cases: list, project_id: str) -> None:
+    for index, case in enumerate(cases, start=1):
+        render_case_payload(case, project_id=project_id, unique_suffix=f"update-{index}")
+
+
+def _ssh_execute(ssh, command: str, *, timeout: int = 1800, check: bool = True) -> tuple[str, str]:
+    exit_code, stdout, stderr = ssh.execute_command(command, timeout=timeout)
+    if check and exit_code != 0:
+        raise RuntimeError(
+            f"Remote command failed with exit {exit_code}: {command}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        )
+    return stdout, stderr
+
+
+def _quote(value: str) -> str:
+    return shlex.quote(str(value))
+
+
+def _read_remote_branch(ssh) -> str:
+    stdout, _ = _ssh_execute(
+        ssh,
+        f"bash -lc {_quote(f'cd {UPDATE_WORKDIR} && git symbolic-ref --short HEAD || echo DETACHED')}",
+        timeout=60,
+    )
+    return stdout.strip() or "DETACHED"
+
+
+def _read_remote_sha(ssh) -> str:
+    stdout, _ = _ssh_execute(
+        ssh,
+        f"bash -lc {_quote(f'cd {UPDATE_WORKDIR} && git rev-parse HEAD')}",
+        timeout=60,
+    )
+    return stdout.strip()
+
+
+def _extract_worker_id_from_cmdline(cmdline: list[str]) -> str | None:
+    for index, item in enumerate(cmdline):
+        if item == "--worker" and index + 1 < len(cmdline):
+            return cmdline[index + 1]
+    return None
+
+
+def _resolve_existing_worker_id(db, pod_id: str, prev_proc: WorkerProcessInfo | None) -> str:
+    if prev_proc:
+        worker_id = _extract_worker_id_from_cmdline(prev_proc.cmdline)
+        if worker_id:
+            return worker_id
+
+    result = db.supabase.table("workers").select("id, metadata, created_at, last_heartbeat").execute()
+    rows = list(getattr(result, "data", None) or [])
+    matching = []
+    for row in rows:
+        metadata = row.get("metadata")
+        if isinstance(metadata, dict) and str(metadata.get("runpod_id")) == pod_id:
+            matching.append(row)
+
+    if not matching:
+        raise RuntimeError(f"Could not resolve existing worker_id for pod {pod_id}")
+
+    matching.sort(
+        key=lambda row: (
+            str(row.get("last_heartbeat") or ""),
+            str(row.get("created_at") or ""),
+        ),
+        reverse=True,
+    )
+    return str(matching[0]["id"])
+
+
+def _build_supervisor_restore_command(workdir: str, cli_args: list[str]) -> str:
+    if not cli_args:
+        raise ValueError("Expected captured supervisor cmdline")
+    return f"cd {_quote(workdir)} && nohup {' '.join(_quote(arg) for arg in cli_args)} > logs/startup.log 2>&1 &"
+
+
+def _should_skip_restore(branch_name: str) -> bool:
+    return branch_name == "DETACHED" or branch_name.startswith("live-test/")
+
+
+def _remote_checkout_and_sync(ssh, branch: str) -> None:
+    command = (
+        f"cd {shlex.quote(UPDATE_WORKDIR)} && "
+        "git fetch origin && "
+        f"git checkout {shlex.quote(branch)} && "
+        f"git pull --ff-only origin {shlex.quote(branch)} && "
+        "uv sync --locked --extra cuda124"
+    )
+    _ssh_execute(ssh, f"bash -lc {_quote(command)}", timeout=3600)
+
+
+def _restore_remote_state(
+    ssh,
+    *,
+    prev_remote_branch: str,
+    prev_remote_sha: str,
+    prev_proc: WorkerProcessInfo | None,
+) -> None:
+    if _should_skip_restore(prev_remote_branch):
+        kill_supervisor_and_worker(ssh)
+        log.info(
+            "skipping pod restore because previous branch was scratch or detached: %s",
+            prev_remote_branch,
+        )
+        return
+
+    kill_supervisor_and_worker(ssh)
+    restore_command = (
+        f"cd {shlex.quote(UPDATE_WORKDIR)} && "
+        f"git checkout {shlex.quote(prev_remote_branch)} && "
+        f"git reset --hard {shlex.quote(prev_remote_sha)} && "
+        "uv sync --locked --extra cuda124"
+    )
+    _ssh_execute(ssh, f"bash -lc {_quote(restore_command)}", timeout=3600)
+
+    if prev_proc is None:
+        log.info("previous pod had no worker process; leaving restored checkout stopped")
+        return
+
+    if prev_proc.family == "supervisor":
+        launch_worker_detached(ssh, _build_supervisor_restore_command(UPDATE_WORKDIR, prev_proc.cmdline))
+        return
+
+    launch_worker_detached(ssh, build_direct_worker_command(UPDATE_WORKDIR, cli_args=prev_proc.cmdline))
+
+
+def _spawn_takeover_pod(db, api_key: str) -> tuple[str, str]:
+    from gpu_orchestrator.worker_spawner import create_worker_spawner
+
+    spawner = create_worker_spawner(config=None, db=db)
+    worker_id = spawner.generate_worker_id()
+    created = asyncio.run(db.create_worker_record(worker_id, spawner.gpu_type))
+    if not created:
+        raise RuntimeError(f"Failed to create worker record for {worker_id}")
+
+    spawn_result = asyncio.run(spawner.spawn_worker(worker_id))
+    if not spawn_result or not spawn_result.get("runpod_id"):
+        raise RuntimeError(f"spawn_worker did not return a runpod_id for {worker_id}")
+
+    pod_id = str(spawn_result["runpod_id"])
+    metadata = {
+        "runpod_id": pod_id,
+        "pod_details": spawn_result.get("pod_details"),
+        "ram_tier": spawn_result.get("ram_tier"),
+        "storage_volume": spawn_result.get("storage_volume"),
+    }
+    asyncio.run(db.update_worker_status(worker_id, "spawning", metadata))
+
+    started = asyncio.run(spawner.start_worker_process(pod_id, worker_id, has_pending_tasks=False))
+    if not started:
+        raise RuntimeError(f"start_worker_process failed for worker {worker_id} on pod {pod_id}")
+
+    return worker_id, pod_id
+
+
+def _print_dry_run_plan(*, cases: list, token: str, args) -> None:
+    supabase_url = config.require_env("SUPABASE_URL")
+    mode = "spawn-takeover" if args.spawn_takeover else "existing"
+    pod_hint = args.pod_id or "<spawned-runpod-id>"
+    worker_hint = "<new-worker-id>" if args.spawn_takeover else "<existing-worker-id>"
+    print("Variant: update")
+    print(f"Mode: {mode}")
+    print(f"Target pod: {pod_hint}")
+    print("Injected env vars:")
+    for key in ("REIGH_ACCESS_TOKEN", "SUPABASE_SERVICE_ROLE_KEY", "SUPABASE_URL", "WORKER_DB_CLIENT_AUTH_MODE"):
+        print(f"- {key}")
+    print("Planned launch command:")
+    print(
+        build_run_worker_command(
+            UPDATE_WORKDIR,
+            reigh_token=token,
+            supabase_url=supabase_url,
+            worker_id=worker_hint,
+            wgp_profile=args.wgp_profile,
+            idle_release_minutes=0,
+        )
+    )
+    print("Planned tasks:")
+    for case in cases:
+        print(f"- {case.name} ({case.task_type}, timeout={case.timeout_sec}s)")
+
+
+def run(args) -> int:
+    context = _prepare_context(args)
+    token = context["token"]
+    db = context["db"]
+    user_id = context["user_id"]
+    project_id = context["project_id"]
+    cases = context["cases"]
+
+    _validate_cases(cases, project_id)
+
+    if args.dry_run:
+        _print_dry_run_plan(cases=cases, token=token, args=args)
+        return 0
+
+    api_key: str | None = None
+    api_key = config.require_env("RUNPOD_API_KEY")
+    supabase_url = config.require_env("SUPABASE_URL")
+    service_role_key = config.require_env("SUPABASE_SERVICE_ROLE_KEY")
+    worker_env = _build_worker_env(token, supabase_url, service_role_key)
+    mode = "spawn-takeover" if args.spawn_takeover else "existing"
+    out_dir = _runs_root() / _timestamp_label()
+
+    ssh = None
+    pod_id: str | None = None
+    worker_id: str | None = None
+    snapshot = None
+    branch: str | None = None
+    preserve_branch = True
+    prev_remote_branch = "DETACHED"
+    prev_remote_sha = ""
+    prev_proc: WorkerProcessInfo | None = None
+
+    try:
+        if args.spawn_takeover:
+            worker_id, pod_id = _spawn_takeover_pod(db, api_key)
+        else:
+            pod_id = args.pod_id
+
+        assert pod_id
+        assert_safe_to_take_over(
+            db,
+            pod_id,
+            user_id,
+            allow_fresh_heartbeat=args.spawn_takeover,
+        )
+
+        snapshot = snapshot_local_state("reigh-worker")
+        branch, _sha = push_working_copy_to_temp_branch("reigh-worker", snapshot)
+
+        ssh = open_session(pod_id, api_key)
+        prev_remote_branch = _read_remote_branch(ssh)
+        prev_remote_sha = _read_remote_sha(ssh)
+        prev_proc = capture_current_worker_cmdline(ssh)
+
+        if not worker_id:
+            worker_id = _resolve_existing_worker_id(db, pod_id, prev_proc)
+
+        _remote_checkout_and_sync(ssh, branch)
+        kill_supervisor_and_worker(ssh)
+        launch_worker_detached(
+            ssh,
+            export_env(worker_env)
+            + " && "
+            + build_run_worker_command(
+                UPDATE_WORKDIR,
+                reigh_token=token,
+                supabase_url=supabase_url,
+                worker_id=worker_id,
+                wgp_profile=args.wgp_profile,
+                idle_release_minutes=0,
+            ),
+        )
+        wait_until_ready(db, worker_id=worker_id, timeout_sec=900)
+
+        results = run_matrix(db, project_id, cases)
+        write_report(results, f"{UPDATE_VARIANT}-{mode}", pod_id, out_dir)
+        _restore_remote_state(
+            ssh,
+            prev_remote_branch=prev_remote_branch,
+            prev_remote_sha=prev_remote_sha,
+            prev_proc=prev_proc,
+        )
+        preserve_branch = False
+        return 0
+    finally:
+        if branch:
+            kept_branch = cleanup_temp_branch(branch, preserve=preserve_branch, submodule_path="reigh-worker")
+            if preserve_branch:
+                print(f"Preserved temp branch for inspection: {kept_branch}")
+        if snapshot is not None:
+            restore_local_state("reigh-worker", snapshot)
+        if ssh is not None:
+            try:
+                logs = fetch_worker_logs(ssh, UPDATE_WORKDIR)
+                out_dir.mkdir(parents=True, exist_ok=True)
+                (out_dir / "worker_logs.txt").write_text(logs, encoding="utf-8")
+            except Exception as exc:
+                log.warning("failed to fetch update variant worker logs: %s", exc)
+            finally:
+                disconnect = getattr(ssh, "disconnect", None)
+                if callable(disconnect):
+                    disconnect()
+        guarded_terminate(pod_id, api_key if not args.dry_run else None, no_terminate=args.no_terminate)
+
+
+__all__ = [
+    "UPDATE_VARIANT",
+    "UPDATE_WORKDIR",
+    "run",
+]


### PR DESCRIPTION
Depends on github.com/banodoco/runpod-lifecycle v0.1.0. Swaps all gpu_orchestrator.runpod.* / RunpodClient call sites in debug/commands/storage.py and scripts/live_test/*. scripts/live_test/tests/test_primitives.py: 28 passed. See banodoco/reigh-worker-orchestrator#1 for the matching orchestrator migration.