### PR TITLE
Add selector-aware claim routing contract

### DIFF
--- a/source/core/db/lifecycle/task_claim_flow.py
+++ b/source/core/db/lifecycle/task_claim_flow.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import os
 from typing import Any, Callable
+
+from source.task_handlers.tasks.template_routing import parse_worker_backend
 
 
 @dataclass(frozen=True)
@@ -44,7 +47,16 @@ def claim_oldest_queued_task(*, worker_id: str, runtime, deps: TaskClaimFlowDepe
 
     response, _error = deps.call_edge_function_with_retry(
         edge_url=request.url,
-        payload={"worker_id": worker_id, "run_type": "gpu"},
+        payload={
+            "worker_id": worker_id,
+            "run_type": "gpu",
+            "worker_backend": parse_worker_backend().value,
+            "selector_namespace": (
+                os.getenv("REIGH_SELECTOR_NAMESPACE")
+                or os.getenv("ROUTE_SELECTOR_NAMESPACE")
+                or "production"
+            ),
+        },
         headers=request.headers,
         function_name="claim-next-task",
     )

--- a/source/core/db/lifecycle/task_completion.py
+++ b/source/core/db/lifecycle/task_completion.py
@@ -7,7 +7,13 @@ _cfg = _task_completion._cfg
 _call_edge_function_with_retry = _task_completion._call_edge_function_with_retry
 
 
-def add_task_to_db(task_payload: dict, task_type_str: str, dependant_on=None, db_path: str | None = None) -> str:
+def add_task_to_db(
+    task_payload: dict,
+    task_type_str: str,
+    dependant_on=None,
+    db_path: str | None = None,
+    route_snapshot_fields: dict | None = None,
+) -> str:
     """Mirror the flat helper while honoring monkeypatches on this shim module."""
     original_retry = _task_completion._call_edge_function_with_retry
     try:
@@ -17,6 +23,7 @@ def add_task_to_db(task_payload: dict, task_type_str: str, dependant_on=None, db
             task_type_str=task_type_str,
             dependant_on=dependant_on,
             db_path=db_path,
+            route_snapshot_fields=route_snapshot_fields,
         )
     finally:
         _task_completion._call_edge_function_with_retry = original_retry

--- a/source/core/db/task_claim.py
+++ b/source/core/db/task_claim.py
@@ -9,6 +9,7 @@ import traceback
 import httpx
 
 from source.core.log import headless_logger
+from source.task_handlers.tasks.template_routing import WorkerBackend, parse_worker_backend
 
 __all__ = [
     "ClaimPollOutcome",
@@ -26,6 +27,128 @@ class ClaimPollOutcome(str, Enum):
     CLAIMED = "claimed"
     EMPTY = "empty"
     ERROR = "error"
+
+
+def _selector_namespace() -> str:
+    value = (
+        os.getenv("REIGH_SELECTOR_NAMESPACE")
+        or os.getenv("ROUTE_SELECTOR_NAMESPACE")
+        or "production"
+    ).strip()
+    return value or "production"
+
+
+def _route_context(task_data: dict | None) -> dict:
+    data = task_data or {}
+    return {
+        "route_key": data.get("route_key"),
+        "selected_backend": data.get("selected_backend"),
+        "selector_namespace": data.get("selector_namespace"),
+        "selector_version": data.get("selector_version"),
+        "claimed_backend": data.get("claimed_backend"),
+        "claimed_selector_namespace": data.get("claimed_selector_namespace"),
+        "claimed_route_key": data.get("claimed_route_key"),
+        "claimed_selector_version": data.get("claimed_selector_version"),
+        "claimed_capability_version": data.get("claimed_capability_version"),
+        "claim_decision_reason": data.get("claim_decision_reason"),
+    }
+
+
+def _int_attempts(value) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _requeue_backend_mismatch(task_id: str, message: str, attempts: int) -> bool:
+    from source.core.db.lifecycle.task_status_retry import requeue_task_for_retry
+
+    return requeue_task_for_retry(
+        task_id,
+        message,
+        attempts,
+        error_category="backend_mismatch",
+    )
+
+
+def _fail_closed_claim_decision(task_id: str, message: str, attempts: int) -> bool:
+    from source.core.db.lifecycle.task_status_complete_remote import mark_task_failed_via_edge_function
+    from source.core.db.lifecycle.task_status_retry import requeue_task_for_retry
+
+    failed = mark_task_failed_via_edge_function(task_id, message)
+    if failed:
+        return True
+
+    return requeue_task_for_retry(
+        task_id,
+        message,
+        attempts,
+        error_category="route_decision_fail_closed",
+    )
+
+
+def _claim_route_guard(task_data: dict, expected_backend: WorkerBackend) -> bool:
+    claimed_backend = task_data.get("claimed_backend")
+    selected_backend = task_data.get("selected_backend")
+    claim_reason = task_data.get("claim_decision_reason")
+    task_id = str(task_data.get("task_id") or task_data.get("id") or "unknown")
+    context = _route_context(task_data)
+
+    # Older task responses do not include route decision fields. Let them run
+    # until the route-aware DB migration is fully deployed.
+    if claimed_backend is None and selected_backend is None and claim_reason is None:
+        return True
+
+    backend_to_validate = claimed_backend if claimed_backend is not None else selected_backend
+    try:
+        returned_backend = parse_worker_backend(str(backend_to_validate))
+    except ValueError:
+        message = (
+            "Malformed route/backend claim decision before execution: "
+            f"expected={expected_backend.value}, context={context}"
+        )
+        cleared = _fail_closed_claim_decision(
+            task_id,
+            message,
+            _int_attempts(task_data.get("attempts")),
+        )
+        headless_logger.error(
+            "[CLAIM] Malformed route/backend claim decision; failing closed "
+            f"task_id={task_id} cleared={cleared} {message}"
+        )
+        return False
+
+    if returned_backend != expected_backend:
+        message = (
+            "Claimed task backend mismatch before execution: "
+            f"expected={expected_backend.value}, claimed={returned_backend.value}, context={context}"
+        )
+        requeued = _requeue_backend_mismatch(task_id, message, _int_attempts(task_data.get("attempts")))
+        headless_logger.error(
+            "[CLAIM] Backend mismatch guard stopped execution "
+            f"task_id={task_id} requeued={requeued} {message}"
+        )
+        return False
+
+    allowed_reasons = {"eligible", "missing_selector_wgp_capability_supported"}
+    if claim_reason is not None and claim_reason not in allowed_reasons:
+        message = (
+            "Unsupported claim decision reason before execution: "
+            f"expected={expected_backend.value}, context={context}"
+        )
+        cleared = _fail_closed_claim_decision(
+            task_id,
+            message,
+            _int_attempts(task_data.get("attempts")),
+        )
+        headless_logger.error(
+            "[CLAIM] Unsupported claim decision reason; failing closed "
+            f"task_id={task_id} cleared={cleared} {message}"
+        )
+        return False
+
+    return True
 
 
 def _resolve_runtime_config(runtime_config=None):
@@ -76,9 +199,13 @@ def check_task_counts_supabase(run_type: str = "gpu", runtime_config=None) -> di
             'Authorization': f'Bearer {access_token}'
         }
 
+        worker_backend = parse_worker_backend()
+        selector_namespace = _selector_namespace()
         payload = {
             "run_type": run_type,
-            "include_active": True
+            "include_active": True,
+            "worker_backend": worker_backend.value,
+            "selector_namespace": selector_namespace,
         }
 
         headless_logger.debug(f"DEBUG check_task_counts_supabase: Calling task-counts at {edge_url}")
@@ -90,7 +217,11 @@ def check_task_counts_supabase(run_type: str = "gpu", runtime_config=None) -> di
             # Always log a concise summary so we can observe behavior without enabling debug
             try:
                 totals = counts_data.get('totals', {})
-                headless_logger.debug_anomaly("TASK_COUNTS", f"totals={totals} run_type={payload.get('run_type')}")
+                headless_logger.debug_anomaly(
+                    "TASK_COUNTS",
+                    f"totals={totals} run_type={payload.get('run_type')} "
+                    f"worker_backend={worker_backend.value} selector_namespace={selector_namespace}",
+                )
             except (ValueError, KeyError, TypeError):
                 # Fall back to raw text if JSON structure unexpected
                 headless_logger.debug_anomaly("TASK_COUNTS", f"raw_response={resp.text[:500]}")
@@ -176,6 +307,13 @@ def poll_next_task(
 
     headless_logger.debug(f"DEBUG: Using worker_id: {worker_id}")
 
+    try:
+        worker_backend = parse_worker_backend()
+    except ValueError as backend_error:
+        headless_logger.error(f"[CLAIM] {backend_error}")
+        return ClaimPollOutcome.ERROR, None
+    selector_namespace = _selector_namespace()
+
     # OPTIMIZATION: Check task counts first to avoid unnecessary claim attempts
     headless_logger.debug("Checking task counts before attempting to claim...")
     task_counts = check_task_counts_supabase("gpu")
@@ -225,6 +363,8 @@ def poll_next_task(
                 "worker_id": worker_id,
                 "run_type": "gpu",
                 "same_model_only": same_model_only,
+                "worker_backend": worker_backend.value,
+                "selector_namespace": selector_namespace,
             }
             if max_task_wait_minutes is not None:
                 payload["max_task_wait_minutes"] = max_task_wait_minutes
@@ -237,8 +377,14 @@ def poll_next_task(
                 task_id = task_data.get('task_id', 'unknown')
                 task_type = task_data.get('task_type', 'unknown')
 
-                headless_logger.debug(f"Claimed task {task_id} (type={task_type})", task_id=task_id)
+                route_context = _route_context(task_data)
+                headless_logger.debug(
+                    f"Claimed task {task_id} (type={task_type}) route_context={route_context}",
+                    task_id=task_id,
+                )
                 headless_logger.debug_anomaly("CLAIM_DEBUG", f"Full task data: {task_data}")
+                if not _claim_route_guard(task_data, worker_backend):
+                    return ClaimPollOutcome.ERROR, None
                 return ClaimPollOutcome.CLAIMED, task_data
             if resp.status_code == 204:
                 headless_logger.debug("Edge Function: No queued tasks available")

--- a/source/core/db/task_completion.py
+++ b/source/core/db/task_completion.py
@@ -13,7 +13,13 @@ from . import config as _cfg
 from .edge_helpers import _call_edge_function_with_retry
 
 
-def add_task_to_db(task_payload: dict, task_type_str: str, dependant_on: str | list[str] | None = None, db_path: str | None = None) -> str:
+def add_task_to_db(
+    task_payload: dict,
+    task_type_str: str,
+    dependant_on: str | list[str] | None = None,
+    db_path: str | None = None,
+    route_snapshot_fields: dict | None = None,
+) -> str:
     """
     Adds a new task to the Supabase database via Edge Function.
 
@@ -23,6 +29,7 @@ def add_task_to_db(task_payload: dict, task_type_str: str, dependant_on: str | l
         dependant_on: Optional dependency - single task ID string or list of task IDs.
                       When list is provided, task will only run when ALL dependencies complete.
         db_path: Ignored (kept for API compatibility)
+        route_snapshot_fields: Optional route fields to lift through create-task for child rows.
 
     Returns:
         str: The database row ID (UUID) assigned to the task
@@ -66,11 +73,27 @@ def add_task_to_db(task_payload: dict, task_type_str: str, dependant_on: str | l
     # Family matches task_types.name in the DB. The edge function has explicit
     # resolvers for frontend-initiated types and a DB-backed passthrough for
     # worker-created types (checks task_types table).
+    route_fields_for_input = dict(route_snapshot_fields or {})
+    allowed_route_fields = {
+        "selector_namespace",
+        "route_key",
+        "selected_backend",
+        "selector_version",
+        "route_selection_snapshot",
+    }
+    unexpected_route_fields = set(route_fields_for_input) - allowed_route_fields
+    if unexpected_route_fields:
+        raise ValueError(
+            "Unexpected route snapshot fields: "
+            f"{sorted(unexpected_route_fields)}"
+        )
+
     payload_edge = {
         "family": task_type_str,
         "project_id": project_id,
         "input": {
             **params_for_db,
+            **route_fields_for_input,
             "task_id": actual_db_row_id,
             "dependant_on": dependant_on_list,
         },

--- a/source/task_handlers/join/task_builder.py
+++ b/source/task_handlers/join/task_builder.py
@@ -11,6 +11,7 @@ from typing import Tuple, List, Optional
 from source.core.db.task_completion import add_task_to_db
 from source.core.log import orchestrator_logger
 from source.task_handlers.join.shared import _check_orchestrator_cancelled
+from source.task_handlers.tasks.template_routing import route_snapshot_fields
 
 __all__ = [
     "_create_join_chain_tasks",
@@ -99,7 +100,14 @@ def _create_join_chain_tasks(
         actual_db_row_id = add_task_to_db(
             task_payload=join_payload,
             task_type_str="join_clips_segment",
-            dependant_on=previous_join_task_id
+            dependant_on=previous_join_task_id,
+            route_snapshot_fields=route_snapshot_fields(
+                task_type="join_clips_segment",
+                params=join_payload,
+                backend="wgp",
+                selector_namespace="production",
+                parent_route_key="join_clips_orchestrator",
+            ),
         )
 
         previous_join_task_id = actual_db_row_id
@@ -131,7 +139,8 @@ def _create_join_chain_tasks(
     final_stitch_task_id = add_task_to_db(
         task_payload=final_stitch_payload,
         task_type_str="join_final_stitch",
-        dependant_on=previous_join_task_id
+        dependant_on=previous_join_task_id,
+        route_snapshot_fields=None,
     )
 
     return True, f"Successfully enqueued {joins_created} chain joins + 1 final stitch for run {run_id}"
@@ -216,7 +225,14 @@ def _create_parallel_join_tasks(
         trans_task_id = add_task_to_db(
             task_payload=transition_payload,
             task_type_str="join_clips_segment",
-            dependant_on=None
+            dependant_on=None,
+            route_snapshot_fields=route_snapshot_fields(
+                task_type="join_clips_segment",
+                params=transition_payload,
+                backend="wgp",
+                selector_namespace="production",
+                parent_route_key="join_clips_orchestrator",
+            ),
         )
 
         transition_task_ids.append(trans_task_id)
@@ -246,7 +262,8 @@ def _create_parallel_join_tasks(
     final_stitch_task_id = add_task_to_db(
         task_payload=final_stitch_payload,
         task_type_str="join_final_stitch",
-        dependant_on=transition_task_ids
+        dependant_on=transition_task_ids,
+        route_snapshot_fields=None,
     )
 
     return True, f"Successfully enqueued {num_joins} parallel transitions + 1 final stitch for run {run_id}"

--- a/source/task_handlers/tasks/template_routing.py
+++ b/source/task_handlers/tasks/template_routing.py
@@ -53,6 +53,22 @@ class ResolvedTask:
         )
 
 
+DIRECT_ROUTE_ALIASES: Mapping[str, str] = MappingProxyType(
+    {
+        "z_image": "z_image_turbo",
+        "z_image_turbo": "z_image_turbo",
+        "z_image_turbo_i2i": "z_image_turbo_i2i",
+        "qwen_image": "qwen_image",
+        "qwen_image_2512": "qwen_image_2512",
+        "optimised_t2i": "wan_2_2_t2i",
+        "wan_2_2_t2i": "wan_2_2_t2i",
+        "qwen_image_edit": "qwen_image_edit",
+        "qwen_image_style": "qwen_image_style",
+        "image_inpaint": "image_inpaint",
+        "annotated_image_edit": "annotated_image_edit",
+    }
+)
+
 SPRINT_2_SELECTOR_MAP: Mapping[str, RouteSelectorEntry] = MappingProxyType(
     {
         "z_image_turbo": RouteSelectorEntry(
@@ -60,6 +76,11 @@ SPRINT_2_SELECTOR_MAP: Mapping[str, RouteSelectorEntry] = MappingProxyType(
             support_state=RouteSupportState.VIBECOMFY_SUPPORTED,
             template_id="image/z_image",
             default_resolution="1024x1024",
+        ),
+        "z_image_turbo_i2i": RouteSelectorEntry(
+            route_key="z_image_turbo_i2i",
+            support_state=RouteSupportState.WGP_ONLY,
+            template_id=None,
         ),
         "qwen_image_2512": RouteSelectorEntry(
             route_key="qwen_image_2512",
@@ -101,6 +122,11 @@ SPRINT_2_SELECTOR_MAP: Mapping[str, RouteSelectorEntry] = MappingProxyType(
             support_state=RouteSupportState.VIBECOMFY_UNSUPPORTED,
             template_id=None,
         ),
+        "join_clips_segment": RouteSelectorEntry(
+            route_key="join_clips_segment",
+            support_state=RouteSupportState.VIBECOMFY_UNSUPPORTED,
+            template_id=None,
+        ),
         "wan_2_2_t2i": RouteSelectorEntry(
             route_key="wan_2_2_t2i",
             support_state=RouteSupportState.WGP_ONLY,
@@ -127,13 +153,13 @@ def derive_route_key(task_type: str, params: Mapping[str, Any] | None = None) ->
     task_params = params or {}
 
     source_task_type = task_params.get("_source_task_type")
-    if source_task_type in {"travel_segment", "individual_travel_segment"}:
-        return _travel_route_key(str(source_task_type), task_params)
+    if source_task_type in _DIMENSIONAL_CHILD_TASK_TYPES:
+        return _dimensional_child_route_key(str(source_task_type), task_params)
 
-    if task_type in {"travel_segment", "individual_travel_segment"}:
-        return _travel_route_key(task_type, task_params)
+    if task_type in _DIMENSIONAL_CHILD_TASK_TYPES:
+        return _dimensional_child_route_key(task_type, task_params)
 
-    return task_type
+    return _direct_route_key(task_type)
 
 
 def resolve_task_route(
@@ -194,6 +220,57 @@ def routing_telemetry_fields(resolved: ResolvedTask) -> dict[str, str | None]:
     }
 
 
+def route_snapshot_fields(
+    *,
+    task_type: str,
+    params: Mapping[str, Any] | None = None,
+    task_id: str | None = None,
+    backend: WorkerBackend | str | None = None,
+    selector_namespace: str = "production",
+    selector_version: int | str | None = None,
+    parent_route_key: str | None = None,
+) -> dict[str, Any]:
+    """Return top-level task route fields plus a JSON-safe snapshot.
+
+    The database migration added these columns for create-time observability and
+    later child-row pinning. Live claim authorization still belongs to the
+    selector/capability RPCs; this helper only serializes the route decision a
+    caller already intends to persist.
+    """
+
+    task_params = dict(params or {})
+    selected_backend = _coerce_backend(backend) if backend is not None else parse_worker_backend()
+    route_key = derive_route_key(task_type, task_params)
+    selector_entry = _selector_entry_for_route_key(route_key)
+    support_state = (
+        selector_entry.support_state
+        if selector_entry is not None
+        else RouteSupportState.VIBECOMFY_UNSUPPORTED
+    )
+    template_id = selector_entry.template_id if selector_entry is not None else None
+
+    snapshot: dict[str, Any] = {
+        "selector_namespace": selector_namespace,
+        "route_key": route_key,
+        "selected_backend": selected_backend.value,
+        "selector_version": selector_version,
+        "support_state": support_state.value,
+        "template_id": template_id,
+    }
+    if task_id is not None:
+        snapshot["task_id"] = task_id
+    if parent_route_key is not None:
+        snapshot["parent_route_key"] = parent_route_key
+
+    return {
+        "selector_namespace": selector_namespace,
+        "route_key": route_key,
+        "selected_backend": selected_backend.value,
+        "selector_version": selector_version,
+        "route_selection_snapshot": snapshot,
+    }
+
+
 def _coerce_backend(backend: WorkerBackend | str) -> WorkerBackend:
     if isinstance(backend, WorkerBackend):
         return backend
@@ -220,20 +297,35 @@ def _is_dimensional_travel_route_key(route_key: str) -> bool:
         (
             "travel_segment__",
             "individual_travel_segment__",
+            "join_clips_segment__",
         )
     )
 
 
-def _travel_route_key(task_type: str, params: Mapping[str, Any]) -> str:
+_DIMENSIONAL_CHILD_TASK_TYPES = frozenset(
+    {
+        "travel_segment",
+        "individual_travel_segment",
+        "join_clips_segment",
+    }
+)
+
+
+def _direct_route_key(task_type: str) -> str:
+    slugged = _slug(task_type)
+    return DIRECT_ROUTE_ALIASES.get(slugged, task_type)
+
+
+def _dimensional_child_route_key(task_type: str, params: Mapping[str, Any]) -> str:
     """Derive the Cohort E child key without importing comparison scripts."""
 
     return "__".join(
         [
             _slug(task_type),
-            f"model-{_slug(_travel_model_family(params))}",
-            f"guidance-{_slug(_travel_guidance_kind(params))}",
-            f"continuity-{_slug(_travel_continuity_case(params))}",
-            f"profile-{_slug(_travel_profile(params))}",
+            f"model-{_slug(_route_model_family(params))}",
+            f"guidance-{_slug(_route_guidance_kind(task_type, params))}",
+            f"continuity-{_slug(_route_continuity_case(task_type, params))}",
+            f"profile-{_slug(_route_profile(params))}",
         ]
     )
 
@@ -246,7 +338,7 @@ def _slug(value: Any) -> str:
     return text or "none"
 
 
-def _travel_model_family(params: Mapping[str, Any]) -> str:
+def _route_model_family(params: Mapping[str, Any]) -> str:
     explicit_family = params.get("model_family")
     if explicit_family:
         return str(explicit_family)
@@ -265,7 +357,7 @@ def _travel_model_family(params: Mapping[str, Any]) -> str:
     return normalized
 
 
-def _travel_guidance_kind(params: Mapping[str, Any]) -> str:
+def _route_guidance_kind(task_type: str, params: Mapping[str, Any]) -> str:
     explicit_kind = params.get("guidance_kind") or params.get("travel_guidance_kind")
     if explicit_kind:
         return str(explicit_kind)
@@ -282,20 +374,24 @@ def _travel_guidance_kind(params: Mapping[str, Any]) -> str:
         return "vace"
     if params.get("video_guide") or params.get("video_mask"):
         return "vace"
+    if task_type == "join_clips_segment" and _route_model_family(params) == "wan22_vace":
+        return "vace"
 
     return "none"
 
 
-def _travel_continuity_case(params: Mapping[str, Any]) -> str:
+def _route_continuity_case(task_type: str, params: Mapping[str, Any]) -> str:
     explicit_case = params.get("continuity_case")
     if explicit_case:
         return str(explicit_case)
+    if task_type == "join_clips_segment":
+        return "join_bridge"
     if params.get("video_source"):
         return "video_source"
     return "first_last"
 
 
-def _travel_profile(params: Mapping[str, Any]) -> str:
+def _route_profile(params: Mapping[str, Any]) -> str:
     return str(
         params.get("profile")
         or params.get("wgp_profile")
@@ -344,6 +440,7 @@ def _extract_memory_profile(params: Mapping[str, Any]) -> str | None:
 
 
 __all__ = [
+    "DIRECT_ROUTE_ALIASES",
     "ResolvedTask",
     "RouteSelectorEntry",
     "RouteSupportState",
@@ -352,6 +449,7 @@ __all__ = [
     "derive_route_key",
     "parse_worker_backend",
     "resolve_task_route",
+    "route_snapshot_fields",
     "route_support_state",
     "routing_telemetry_fields",
 ]

--- a/source/task_handlers/travel/orchestrator.py
+++ b/source/task_handlers/travel/orchestrator.py
@@ -23,6 +23,7 @@ from ...core.params.travel_guidance import AnchorEntry, TravelGuidanceConfig
 from ...core.params.task_result import TaskResult
 from ...core.log.display_names import friendly_child_id, friendly_task_id, rel_path
 from ...runtime.wgp_bridge import get_model_fps, get_model_min_frames_and_step
+from ..tasks.template_routing import route_snapshot_fields
 
 from .svi_config import SVI_DEFAULT_PARAMS, SVI_STITCH_OVERLAP
 from .debug_utils import flush_ram_snapshots, log_ram_usage
@@ -2241,7 +2242,14 @@ def handle_travel_orchestrator_task(task_params_from_db: dict, main_output_dir_b
             actual_db_row_id = db_ops.add_task_to_db(
                 task_payload=segment_payload,
                 task_type_str="travel_segment",
-                dependant_on=previous_segment_task_id
+                dependant_on=previous_segment_task_id,
+                route_snapshot_fields=route_snapshot_fields(
+                    task_type="travel_segment",
+                    params=segment_payload,
+                    backend="wgp",
+                    selector_namespace="production",
+                    parent_route_key="travel_orchestrator",
+                ),
             )
             # Record the actual DB ID so subsequent segments depend on the real DB row ID
             actual_segment_db_id_by_index[idx] = actual_db_row_id
@@ -2352,7 +2360,8 @@ def handle_travel_orchestrator_task(task_params_from_db: dict, main_output_dir_b
             actual_stitch_db_row_id = db_ops.add_task_to_db(
                 task_payload=stitch_payload, 
                 task_type_str="travel_stitch",
-                dependant_on=last_segment_task_id
+                dependant_on=last_segment_task_id,
+                route_snapshot_fields=None,
             )
             
             # Post-insert verification of dependency from DB
@@ -2451,7 +2460,8 @@ def handle_travel_orchestrator_task(task_params_from_db: dict, main_output_dir_b
             join_orchestrator_task_id = db_ops.add_task_to_db(
                 task_payload={"orchestrator_details": join_orchestrator_payload},
                 task_type_str="join_clips_orchestrator",
-                dependant_on=all_segment_task_ids  # Multi-dependency: all segments must complete
+                dependant_on=all_segment_task_ids,  # Multi-dependency: all segments must complete
+                route_snapshot_fields=None,
             )
             travel_logger.debug(
                 f"[JOIN_STITCH] created id={join_orchestrator_task_id}, dependency_count={len(all_segment_task_ids)}",

--- a/source/task_handlers/travel/stitch.py
+++ b/source/task_handlers/travel/stitch.py
@@ -812,7 +812,8 @@ def _handle_travel_stitch_task(task_params_from_db: dict, main_output_dir_base: 
 
             db_ops.add_task_to_db(
                 task_payload=upscale_payload,
-                task_type_str=upscaler_engine_to_use
+                task_type_str=upscaler_engine_to_use,
+                route_snapshot_fields=None,
             )
             travel_logger.debug(f"Enqueued upscale sub-task {upscale_sub_task_id} ({upscaler_engine_to_use}). Waiting...", task_id=stitch_task_id_str)
 

--- a/tests/test_template_routing.py
+++ b/tests/test_template_routing.py
@@ -4,8 +4,15 @@ import ast
 import importlib.util
 import sys
 from pathlib import Path
+from types import ModuleType, SimpleNamespace
 
 import pytest
+
+sys.modules.setdefault("httpx", SimpleNamespace(HTTPError=Exception))
+postgrest_exceptions = ModuleType("postgrest.exceptions")
+postgrest_exceptions.APIError = Exception
+sys.modules.setdefault("postgrest", ModuleType("postgrest"))
+sys.modules.setdefault("postgrest.exceptions", postgrest_exceptions)
 
 
 MODULE_PATH = (
@@ -42,6 +49,22 @@ def test_supported_direct_routes_resolve_to_vibecomfy_templates(routing) -> None
     assert z_image.support_state == routing.RouteSupportState.VIBECOMFY_SUPPORTED
     assert z_image.template_id == "image/z_image"
     assert z_image.should_use_vibecomfy is True
+
+
+@pytest.mark.parametrize(
+    ("task_type", "expected_route_key"),
+    [
+        ("z_image", "z_image_turbo"),
+        ("z_image_turbo_i2i", "z_image_turbo_i2i"),
+        ("optimised_t2i", "wan_2_2_t2i"),
+        ("qwen_image", "qwen_image"),
+        ("image-upscale", "image-upscale"),
+    ],
+)
+def test_direct_route_aliases_match_canonical_selector_keys(
+    routing, task_type: str, expected_route_key: str
+) -> None:
+    assert routing.derive_route_key(task_type, {}) == expected_route_key
 
 
 @pytest.mark.parametrize(
@@ -176,6 +199,46 @@ def test_travel_route_key_distinguishes_wan_vace_payload_context(routing) -> Non
     assert "will not fall back to WGP" in resolved.fail_closed_reason
 
 
+def test_join_clips_segment_uses_dimensional_route_key(routing) -> None:
+    resolved = routing.resolve_task_route(
+        task_id="join-child",
+        task_type="join_clips_segment",
+        params={
+            "model": "wan_2_2_vace_lightning_baseline_2_2_2",
+            "model_family": "wan22_vace",
+            "guidance_kind": "vace",
+            "continuity_case": "join_bridge",
+            "wgp_profile": "default",
+        },
+        backend="vibecomfy",
+    )
+
+    assert (
+        resolved.route_key
+        == "join_clips_segment__model-wan22_vace__guidance-vace__continuity-join_bridge__profile-default"
+    )
+    assert resolved.support_state == routing.RouteSupportState.VIBECOMFY_UNSUPPORTED
+    assert resolved.template_id is None
+    assert resolved.should_use_vibecomfy is False
+    assert resolved.fail_closed_reason
+    assert "will not fall back to WGP" in resolved.fail_closed_reason
+
+
+def test_join_clips_segment_defaults_to_join_bridge_for_wan_vace(routing) -> None:
+    resolved = routing.resolve_task_route(
+        task_id="join-child-defaults",
+        task_type="join_clips_segment",
+        params={"model": "wan_2_2_vace_lightning_baseline_2_2_2"},
+        backend="wgp",
+    )
+
+    assert (
+        resolved.route_key
+        == "join_clips_segment__model-wan22_vace__guidance-vace__continuity-join_bridge__profile-default"
+    )
+    assert resolved.fail_closed_reason is None
+
+
 def test_wan_2_2_t2i_remains_wgp_only_even_when_vibecomfy_is_explicit(routing) -> None:
     resolved = routing.resolve_task_route(
         task_id="wan-image",
@@ -210,6 +273,45 @@ def test_unset_backend_and_wgp_backend_preserve_wgp_defaults(routing, monkeypatc
     )
     assert explicit_wgp.backend == routing.WorkerBackend.WGP
     assert explicit_wgp.fail_closed_reason is None
+
+
+def test_route_snapshot_fields_are_top_level_columns_plus_json_snapshot(routing) -> None:
+    fields = routing.route_snapshot_fields(
+        task_id="child-1",
+        task_type="join_clips_segment",
+        params={
+            "model": "wan_2_2_vace_lightning_baseline_2_2_2",
+            "model_family": "wan22_vace",
+            "guidance_kind": "vace",
+            "continuity_case": "join_bridge",
+            "wgp_profile": "default",
+        },
+        backend="wgp",
+        selector_namespace="production",
+        selector_version=42,
+        parent_route_key="join_clips_orchestrator",
+    )
+
+    route_key = (
+        "join_clips_segment__model-wan22_vace__guidance-vace__"
+        "continuity-join_bridge__profile-default"
+    )
+    assert fields == {
+        "selector_namespace": "production",
+        "route_key": route_key,
+        "selected_backend": "wgp",
+        "selector_version": 42,
+        "route_selection_snapshot": {
+            "selector_namespace": "production",
+            "route_key": route_key,
+            "selected_backend": "wgp",
+            "selector_version": 42,
+            "support_state": "vibecomfy_unsupported",
+            "template_id": None,
+            "task_id": "child-1",
+            "parent_route_key": "join_clips_orchestrator",
+        },
+    }
 
 
 def test_reigh_backend_vibecomfy_is_parsed_strictly(routing, monkeypatch) -> None:
@@ -255,3 +357,276 @@ def test_module_has_no_wgp_heavy_or_vibecomfy_imports() -> None:
     assert "vibecomfy" not in imported_roots
     assert "source" not in imported_roots
     assert not any("wgp" in module.lower() for module in imported_modules)
+
+
+def test_claim_route_guard_requeues_backend_mismatch(monkeypatch) -> None:
+    from source.core.db import task_claim
+
+    requeue_calls = []
+
+    def _fake_requeue(task_id, error_message, current_attempts, error_category=None):
+        requeue_calls.append((task_id, error_message, current_attempts, error_category))
+        return True
+
+    monkeypatch.setattr(
+        "source.core.db.lifecycle.task_status_retry.requeue_task_for_retry",
+        _fake_requeue,
+    )
+
+    allowed = task_claim._claim_route_guard(
+        {
+            "task_id": "task-mismatch",
+            "attempts": 2,
+            "claimed_backend": "vibecomfy",
+            "claimed_selector_namespace": "production",
+            "claimed_route_key": "z_image_turbo",
+            "claim_decision_reason": "eligible",
+        },
+        task_claim.WorkerBackend.WGP,
+    )
+
+    assert allowed is False
+    assert len(requeue_calls) == 1
+    assert requeue_calls[0][0] == "task-mismatch"
+    assert requeue_calls[0][2] == 2
+    assert requeue_calls[0][3] == "backend_mismatch"
+
+
+def test_claim_route_guard_fails_closed_on_malformed_decision(monkeypatch) -> None:
+    from source.core.db import task_claim
+
+    failed_calls = []
+    requeue_calls = []
+
+    def _fake_fail(task_id, message):
+        failed_calls.append((task_id, message))
+        return True
+
+    def _fake_requeue(task_id, error_message, current_attempts, error_category=None):
+        requeue_calls.append((task_id, error_message, current_attempts, error_category))
+        return True
+
+    monkeypatch.setattr(
+        "source.core.db.lifecycle.task_status_complete_remote.mark_task_failed_via_edge_function",
+        _fake_fail,
+    )
+    monkeypatch.setattr(
+        "source.core.db.lifecycle.task_status_retry.requeue_task_for_retry",
+        _fake_requeue,
+    )
+
+    assert task_claim._claim_route_guard(
+        {
+            "task_id": "task-malformed",
+            "attempts": 4,
+            "claimed_backend": "comfy",
+            "claimed_selector_namespace": "production",
+            "claimed_route_key": "z_image_turbo",
+            "claim_decision_reason": "eligible",
+        },
+        task_claim.WorkerBackend.WGP,
+    ) is False
+    assert len(failed_calls) == 1
+    assert failed_calls[0][0] == "task-malformed"
+    assert "Malformed route/backend claim decision before execution" in failed_calls[0][1]
+    assert requeue_calls == []
+
+
+def test_claim_route_guard_requeues_when_fail_closed_update_is_unavailable(monkeypatch) -> None:
+    from source.core.db import task_claim
+
+    failed_calls = []
+    requeue_calls = []
+
+    def _fake_fail(task_id, message):
+        failed_calls.append((task_id, message))
+        return False
+
+    def _fake_requeue(task_id, error_message, current_attempts, error_category=None):
+        requeue_calls.append((task_id, error_message, current_attempts, error_category))
+        return True
+
+    monkeypatch.setattr(
+        "source.core.db.lifecycle.task_status_complete_remote.mark_task_failed_via_edge_function",
+        _fake_fail,
+    )
+    monkeypatch.setattr(
+        "source.core.db.lifecycle.task_status_retry.requeue_task_for_retry",
+        _fake_requeue,
+    )
+
+    assert task_claim._claim_route_guard(
+        {
+            "task_id": "task-unsupported",
+            "attempts": 1,
+            "claimed_backend": "wgp",
+            "claimed_selector_namespace": "production",
+            "claimed_route_key": "z_image_turbo",
+            "claim_decision_reason": "unsupported_capability",
+        },
+        task_claim.WorkerBackend.WGP,
+    ) is False
+    assert len(failed_calls) == 1
+    assert "Unsupported claim decision reason before execution" in failed_calls[0][1]
+    assert len(requeue_calls) == 1
+    assert requeue_calls[0][0] == "task-unsupported"
+    assert requeue_calls[0][2] == 1
+    assert requeue_calls[0][3] == "route_decision_fail_closed"
+
+
+def test_claim_flow_sends_backend_and_selector_namespace(monkeypatch) -> None:
+    from source.core.db.config import DBRuntimeConfig
+    from source.core.db.lifecycle.task_claim_flow import (
+        TaskClaimFlowDependencies,
+        claim_oldest_queued_task,
+    )
+
+    monkeypatch.setenv("REIGH_BACKEND", "vibecomfy")
+    monkeypatch.setenv("REIGH_SELECTOR_NAMESPACE", "staging")
+    captured_payload = {}
+
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"task_id": "claimed-2", "task_type": "z_image_turbo", "params": {}}
+
+    def _call_edge_function_with_retry(**kwargs):
+        captured_payload.update(kwargs["payload"])
+        return _Response(), None
+
+    runtime = DBRuntimeConfig(
+        db_type="supabase",
+        pg_table_name="tasks",
+        supabase_url="https://example.supabase.co",
+        supabase_service_key="svc",
+        supabase_video_bucket="bucket",
+        supabase_client=object(),
+        supabase_access_token="token",
+        supabase_edge_complete_task_url=None,
+        supabase_edge_create_task_url=None,
+        supabase_edge_claim_task_url="https://example.supabase.co/functions/v1/claim-next-task",
+        debug_mode=False,
+    )
+    result = claim_oldest_queued_task(
+        worker_id="worker-vibe",
+        runtime=runtime,
+        deps=TaskClaimFlowDependencies(
+            check_my_assigned_tasks=lambda *_args, **_kwargs: None,
+            check_task_counts_supabase=lambda *_args, **_kwargs: {"totals": {"queued_only": 1}},
+            orchestrator_has_incomplete_children=lambda *_args, **_kwargs: False,
+            register_orchestrator_deferral=lambda _task_id: (False, 1),
+            clear_orchestrator_deferral=lambda _task_id: None,
+            resolve_edge_request=lambda *_args, **_kwargs: SimpleNamespace(
+                url="https://example.supabase.co/functions/v1/claim-next-task",
+                headers={"Authorization": "Bearer token"},
+            ),
+            call_edge_function_with_retry=_call_edge_function_with_retry,
+            has_required_edge_credentials=lambda headers: "Authorization" in headers,
+        ),
+    )
+
+    assert result == {"task_id": "claimed-2", "task_type": "z_image_turbo", "params": {}}
+    assert captured_payload == {
+        "worker_id": "worker-vibe",
+        "run_type": "gpu",
+        "worker_backend": "vibecomfy",
+        "selector_namespace": "staging",
+    }
+
+
+def test_add_task_to_db_lifts_route_snapshot_fields_into_create_task_payload(monkeypatch) -> None:
+    from source.core.db import task_completion
+
+    captured_payload = {}
+
+    class _Response:
+        status_code = 200
+        text = "ok"
+
+    def _fake_edge_call(**kwargs):
+        captured_payload.update(kwargs["payload"])
+        return _Response(), None
+
+    monkeypatch.setattr(task_completion._cfg, "SUPABASE_EDGE_CREATE_TASK_URL", "https://edge.test/create-task", raising=False)
+    monkeypatch.setattr(task_completion._cfg, "SUPABASE_URL", None, raising=False)
+    monkeypatch.setattr(task_completion._cfg, "SUPABASE_ACCESS_TOKEN", "token", raising=False)
+    monkeypatch.setattr(task_completion, "_call_edge_function_with_retry", _fake_edge_call)
+    monkeypatch.setattr("uuid.uuid4", lambda: "task-fixed-id")
+
+    route_fields = {
+        "selector_namespace": "production",
+        "route_key": "join_clips_segment__model-wan22_vace__guidance-vace__continuity-join_bridge__profile-default",
+        "selected_backend": "wgp",
+        "selector_version": 12,
+        "route_selection_snapshot": {
+            "selector_namespace": "production",
+            "route_key": "join_clips_segment__model-wan22_vace__guidance-vace__continuity-join_bridge__profile-default",
+            "selected_backend": "wgp",
+            "selector_version": 12,
+        },
+    }
+
+    task_id = task_completion.add_task_to_db(
+        task_payload={"project_id": "project-1", "prompt": "bridge"},
+        task_type_str="join_clips_segment",
+        route_snapshot_fields=route_fields,
+    )
+
+    assert task_id == "task-fixed-id"
+    assert captured_payload["input"]["task_id"] == "task-fixed-id"
+    for key, value in route_fields.items():
+        assert captured_payload["input"][key] == value
+    assert captured_payload["input"]["prompt"] == "bridge"
+
+
+def test_parallel_join_child_creation_snapshots_transitions_and_leaves_final_null(monkeypatch, tmp_path) -> None:
+    from source.task_handlers.join import task_builder
+
+    calls = []
+
+    def _fake_add_task_to_db(**kwargs):
+        calls.append(kwargs)
+        return f"created-{len(calls)}"
+
+    monkeypatch.setattr(task_builder, "add_task_to_db", _fake_add_task_to_db)
+
+    ok, message = task_builder._create_parallel_join_tasks(
+        clip_list=[
+            {"url": "https://example.com/a.mp4"},
+            {"url": "https://example.com/b.mp4"},
+            {"url": "https://example.com/c.mp4"},
+        ],
+        run_id="join-run-1",
+        join_settings={
+            "model": "wan_2_2_vace_lightning_baseline_2_2_2",
+            "guidance_kind": "vace",
+            "continuity_case": "join_bridge",
+            "wgp_profile": "default",
+            "fps": 16,
+        },
+        per_join_settings=[],
+        vlm_enhanced_prompts=[],
+        current_run_output_dir=tmp_path,
+        orchestrator_task_id_str="join-orch-1",
+        orchestrator_project_id="project-1",
+        orchestrator_payload={"fps": 16},
+        parent_generation_id="parent-1",
+    )
+
+    assert ok is True
+    assert "parallel transitions" in message
+    assert [call["task_type_str"] for call in calls] == [
+        "join_clips_segment",
+        "join_clips_segment",
+        "join_final_stitch",
+    ]
+    for call in calls[:2]:
+        assert call["route_snapshot_fields"]["route_key"] == (
+            "join_clips_segment__model-wan22_vace__guidance-vace__"
+            "continuity-join_bridge__profile-default"
+        )
+        assert call["route_snapshot_fields"]["selected_backend"] == "wgp"
+        assert call["route_snapshot_fields"]["route_selection_snapshot"]["parent_route_key"] == "join_clips_orchestrator"
+    assert calls[2]["route_snapshot_fields"] is None


### PR DESCRIPTION
Sprint 06 worker route selector and claim contract changes.\n\nIncludes:\n- Python route-key serialization for direct, travel, individual travel, and join child routes\n- route snapshot helper output for child task pinning\n- worker backend/selector namespace claim payloads\n- pre-execution claim backend guard with requeue/fail-closed behavior\n- child route snapshot propagation through travel/join/task-completion paths\n\nValidation:\n- PYTHONPATH=. pytest tests/test_template_routing.py\n\nNote: this is stacked on Sprint 05's branch.